### PR TITLE
Backward compatible fix to be compatible with coq/coq#7451.

### DIFF
--- a/Util/Set/Ramsey.v
+++ b/Util/Set/Ramsey.v
@@ -10,6 +10,7 @@ After "On a Problem of Formal Logic", F. P. Ramsey, London
 Math. Soc. s2-30(1):264-286, 1930, doi:10.1112/plms/s2-30.1.264. *)
 
 Set Implicit Arguments.
+Set Nested Proofs Allowed.
 
 From Coq Require Import Morphisms Basics Setoid.
 From CoLoR Require Import ClassicUtil IotaUtil EpsilonUtil DepChoice


### PR DESCRIPTION
coq/coq#7451 forbids the use of nested lemmas unless option Nested Proofs Allowed is turned off.
This PR adds the option in the only file that was using nested lemmas.
The fix is backward compatible because unknown options do not result in a failure but just in a warning.