### PR TITLE
Fix #6: `fix` tactic without a name is deprecated.

### DIFF
--- a/Coccinelle/basis/decidable_set.v
+++ b/Coccinelle/basis/decidable_set.v
@@ -65,6 +65,6 @@ End Convert.
 
 Lemma beq_nat_ok : forall n1 n2, if beq_nat n1 n2 then n1 = n2 else n1 <> n2.
 Proof.
-fix 1; intros [ | n1] [ | n2]; simpl; try reflexivity; try discriminate.
+fix beq_nat_ok 1; intros [ | n1] [ | n2]; simpl; try reflexivity; try discriminate.
 generalize (beq_nat_ok n1 n2); case (beq_nat n1 n2); [intro; subst; reflexivity | intros n1_diff_n2 H; apply n1_diff_n2; injection H; intro; assumption].
 Defined.

--- a/Coccinelle/basis/ordered_set.v
+++ b/Coccinelle/basis/ordered_set.v
@@ -106,7 +106,7 @@ Function eq_bool (n m : nat) {struct n} : bool :=
   end.
 
 Lemma eq_bool_ok : forall a1 a2, match eq_bool a1 a2 with true => a1 = a2 | false => ~a1 = a2 end.
-fix 1.
+fix eq_bool_ok 1.
 intros [ | n] [ | m]; simpl.
 reflexivity.
 discriminate.
@@ -124,7 +124,7 @@ Function o_bool (n m : nat) {struct n} : bool :=
   end.
 
 Lemma o_bool_ok : forall a1 a2, match o_bool a1 a2 with true => o a1 a2 | false => ~ o a1 a2 end.
-unfold o; fix 1.
+unfold o; fix o_bool_ok 1.
 intros [ | n] [ | m]; simpl.
 apply le_n.
 apply le_O_n.

--- a/Coccinelle/examples/cime_trace/equational_extension.v
+++ b/Coccinelle/examples/cime_trace/equational_extension.v
@@ -144,7 +144,7 @@ Lemma one_step_ind2
 .
 Proof.
   intros R P P0 H H0 H1 H2.
-  fix 3.
+  fix one_step_ind2 3.
   intros t t0 [t1 t2 a|f l1 l2 o].
   apply H.
   apply H0.

--- a/Coccinelle/list_extensions/dickson.v
+++ b/Coccinelle/list_extensions/dickson.v
@@ -553,7 +553,7 @@ intros [e1 l1] [e2 l2]; simpl.
 generalize (DS1.eq_bool_ok e1 e2); case (DS1.eq_bool e1 e2); [intros e1_eq_e2 | intros e1_diff_e2].
 revert l1 l2.
 assert (H :  forall l1 l2, match eq_bool_list l1 l2 with true => l1 = l2 | false => ~l1 = l2 end).
-fix 1.
+fix eq_bool_ok0 1.
 intros [ | a1 l1] [ | a2 l2]; simpl.
 apply eq_refl.
 discriminate.
@@ -1003,7 +1003,7 @@ Lemma greater_case :
                               (forall a la, In (a,la) ll -> forall b, mem eq_A b la -> R b a).
 Proof. 
 intros l1 l2; revert l2 l1.
-fix 1.
+fix greater_case 1.
 intros [ | a2 l2].
 intros [ | a1 l1]; simpl.
 intros _ _; exists (@nil A);  exists (@nil (A * list A)); simpl; intuition.

--- a/Coccinelle/list_extensions/list_permut.v
+++ b/Coccinelle/list_extensions/list_permut.v
@@ -1090,7 +1090,7 @@ Definition permut_bool :=
 Lemma permut_bool_ok : 
 forall l1 l2, match permut_bool l1 l2 with true => permut l1 l2 | false => ~permut l1 l2 end.
 Proof.
-fix 1.
+fix permut_bool_ok 1.
 intro l1; case l1; clear l1.
 intro l2; case l2; clear l2.
 simpl; apply Pnil.
@@ -1220,7 +1220,7 @@ Lemma remove_eq_eq :
   | None => remove eq_bool a' l = None
   end.
 Proof.
-fix 1.
+fix remove_eq_eq 1.
 intros [ | b l] a a' a_eq_a'; simpl.
 apply eq_refl.
 case_eq (eq_bool a b); [intro a_eq_b | intro a_diff_b].
@@ -1245,7 +1245,7 @@ Defined.
 Lemma remove_equiv_nil_2 :
   forall l, remove_equiv eq_bool l nil = (l,nil).
 Proof.
-fix 1.
+fix remove_equiv_nil_2 1.
 intros [ | a l]; simpl.
 apply eq_refl.
 rewrite remove_equiv_nil_2; apply eq_refl.
@@ -1390,7 +1390,7 @@ Lemma remove_equiv_permut_2:
       (fst (remove_equiv eq_bool l1 l2) =  fst (remove_equiv eq_bool l1 l2') /\
           permut (snd (remove_equiv eq_bool l1 l2)) (snd (remove_equiv eq_bool l1 l2'))).
 Proof.
-fix 1.
+fix remove_equiv_permut_2 1.
 intros [ | a1 l1] l2 l2' P.
 simpl; split; [apply eq_refl | trivial].
 simpl; generalize (remove_permut P a1).

--- a/Coccinelle/list_extensions/list_set.v
+++ b/Coccinelle/list_extensions/list_set.v
@@ -81,7 +81,7 @@ Definition without_red l := without_red_bool l = true.
 Lemma without_red_remove :
   forall e l1 l2, without_red (l1 ++ e :: l2) -> without_red (l1 ++ l2).
 Proof.
-unfold without_red; fix 2.
+unfold without_red; fix without_red_remove 2.
 intros e l1 l2; case l1; clear l1; simpl.
 case (mem_bool eq_bool e l2); [intro H; discriminate | trivial].
 intros e1 l1;
@@ -98,7 +98,7 @@ Qed.
 Lemma without_red_not_in :
   forall e l1 l2, without_red (l1 ++ e :: l2) -> ~mem eq_A e (l1 ++ l2).
 Proof.
-unfold without_red; fix 2.
+unfold without_red; fix without_red_not_in 2.
 intros e l1 l2; case l1; clear l1; simpl.
 generalize (mem_bool_ok _ _ eq_bool_ok e l2); case (mem_bool eq_bool e l2).
 intros _ H _; discriminate.
@@ -115,7 +115,7 @@ Lemma add_prf :
   forall e l1 l2, without_red (l1 ++ l2) -> ~mem eq_A e (l1 ++ l2) ->
   without_red (l1 ++ e :: l2).
 Proof.
-unfold without_red; fix 2.
+unfold without_red; fix add_prf 2.
 intros e l1 l2; case l1; clear l1; simpl.
 intros wr12 e_not_in_l1_l2; 
 generalize (mem_bool_ok _ _ eq_bool_ok e l2); case (mem_bool eq_bool e l2).
@@ -136,7 +136,7 @@ Qed.
 Lemma without_red_permut :
  forall l1 l2, without_red l1 -> LP.permut l1 l2 -> without_red l2.
 Proof.
-unfold without_red; fix 1.
+unfold without_red; fix without_red_permut 1.
 intros l1; case l1; clear l1.
 intros l2 _ P; rewrite (permut_nil (permut_sym P)); reflexivity.
 intros a1 l1 l2; simpl.
@@ -170,7 +170,7 @@ Function remove_red (l : list A) : list A :=
 Lemma included_remove_red : 
 forall e l, mem eq_A e (remove_red l) -> mem eq_A e l.
 Proof.
-fix 2.
+fix included_remove_red 2.
 intros x l; case l; clear l.
 intro H; exact H.
 intros a l; simpl; case (mem_bool eq_bool a l).
@@ -182,7 +182,7 @@ Qed.
 
 Lemma remove_red_included : forall e l, mem eq_A e l -> mem eq_A e (remove_red l).
 Proof.
-fix 2.
+fix remove_red_included 2.
 intros x l; case l; clear l.
 intro H; exact H.
 intros a l; simpl; generalize (mem_bool_ok _ _ eq_bool_ok a l); case (mem_bool eq_bool a l).
@@ -197,7 +197,7 @@ Qed.
 
 Lemma without_red_remove_red :  forall l, without_red (remove_red l).
 Proof.
-unfold without_red; fix 1.
+unfold without_red; fix without_red_remove_red 1.
 intro l; case l; clear l.
 reflexivity.
 intros a l; simpl.
@@ -308,7 +308,7 @@ Qed.
 Lemma without_red_filter_aux :  
   forall P_bool l, without_red l -> without_red (filter_aux P_bool l).
 Proof.
-unfold without_red; fix 2.
+unfold without_red; fix without_red_filter_aux 2.
 intros P_bool l; case l; clear l.
 intros _; reflexivity.
 simpl; intros a l.
@@ -424,7 +424,7 @@ Definition union s1 s2 := mk_set (without_red_add_without_red s2.(support) s1.(i
 Lemma union_1_aux :
 forall (l1 l2 : list A) (e : A), more_list.mem eq_A e l1 -> more_list.mem eq_A e (add_without_red l1 l2).
 Proof.
-fix 2.
+fix union_1_aux 2.
 intros l1 l2; case l2; clear l2.
 intros; assumption.
 intros a2 l2 e e_in_l1; simpl.
@@ -441,7 +441,7 @@ Qed.
 Lemma union_2_aux :
 forall (l1 l2 : list A) (e : A), more_list.mem eq_A e l2 -> more_list.mem eq_A e (add_without_red l1 l2).
 Proof.
-fix 2.
+fix union_2_aux 2.
 intros l1 l2; case l2; clear l2.
 intros; contradiction.
 intros a2 l2 e e_in_a2l2; simpl in e_in_a2l2; simpl.
@@ -489,7 +489,7 @@ Function remove_not_common (acc l1 l2 : list A) {struct l2} : list A :=
 
 Lemma length_remove_not_common : 
    forall l1 l2 acc, length (remove_not_common acc l1 l2) = length acc + length (remove_not_common nil l1 l2).
-fix 2.
+fix length_remove_not_common 2.
 intros l1 l2 acc; case l2; clear l2; simpl.
 rewrite <- plus_n_O; reflexivity.
 intros a2 l2; case (mem_bool eq_bool a2 l1).
@@ -638,7 +638,7 @@ Definition subset s1 s2 : Prop :=
 Lemma subset_dec : forall s1 s2, {subset s1 s2} + {~ subset s1 s2}.
 Proof.
 unfold subset, mem; intros s1 s2; case s1; clear s1; simpl; intros l1 _; case s2; clear s2; simpl; intros l2 _.
-revert l1 l2; fix 1.
+revert l1 l2; fix subset_dec 1.
 intros l1; case l1; clear l1; simpl.
 (* 1/2  l1 = [] *)
 intros l2; left; intros; contradiction.
@@ -896,7 +896,7 @@ Proof.
 intro s1; case s1; clear s1; intros l1 wr1.
 intro s2; case s2; clear s2; intros l2 wr2.
 revert l1 wr1 l2 wr2; unfold subset, cardinal, mem, without_red; simpl.
-fix 1.
+fix cardinal_subset 1.
 intro l1; case l1; clear l1.
 intros _ l2 _ _; apply le_O_n.
 simpl; intros a1 l1.
@@ -940,7 +940,7 @@ Proof.
 intro s1; case s1; clear s1; intros l1 wr1.
 intro s2; case s2; clear s2; intros l2 wr2.
 revert l1 wr1 l2 wr2; unfold without_red, cardinal; simpl.
-fix 3.
+fix cardinal_union_inter_12 3.
 intros l1 wr1 l2; case l2; clear l2; simpl.
 intros _; reflexivity.
 intros a2 l2; generalize (mem_bool_ok _ _ eq_bool_ok a2 l2); case_eq (mem_bool eq_bool a2 l2).
@@ -994,7 +994,7 @@ Proof.
 intro s1; case s1; clear s1; intros l1 wr1.
 intro s2; case s2; clear s2; intros l2 wr2.
 revert l1 wr1 l2 wr2; unfold without_red, cardinal, subset, mem; simpl.
-fix 1.
+fix subset_cardinal_not_eq_not_eq_set 1.
 intros l1 wr1 l2 wr2 a l1_in_l2 a_not_in_l1 a_in_l2.
 case (mem_split_set _ _ eq_bool_ok _ _ a_in_l2); 
 intros a' M; case M; clear M.

--- a/Coccinelle/list_extensions/list_sort.v
+++ b/Coccinelle/list_extensions/list_sort.v
@@ -364,7 +364,7 @@ Lemma in_remove_list :
   | Some rmv => permut (la ++ rmv) l
   end.
 Proof.
-fix 1.
+fix in_remove_list 1.
 intro l; case l; clear l.
 (* l = [] *)
 intro la; simpl; case la; clear la.

--- a/Coccinelle/list_extensions/more_list.v
+++ b/Coccinelle/list_extensions/more_list.v
@@ -173,7 +173,7 @@ Qed.
 Lemma split_map_set : forall (A B : Type) (f : A -> B) l l1 l2, map f l = l1 ++ l2 -> 
    {k1 : list A & {k2 : list A | l = k1 ++ k2 /\ map f k1 = l1 /\ map f k2 = l2}}.
 Proof.
-fix 4.
+fix split_map_set 4.
 intros A B f l; case l; clear l.
 intros l1 l2 H; exists nil; exists nil.
 revert H; case l1; clear l1.
@@ -206,7 +206,7 @@ Qed.
 
 Lemma flat_map_app : 
 	forall A B (f : A -> list B) (l1 l2 : list A), flat_map f (l1 ++ l2) = (flat_map f l1) ++ (flat_map f l2).
-intros A B f; fix 1.
+intros A B f; fix flat_map_app 1.
 intros l1; case l1; clear l1.
 intros l2; apply eq_refl.
 intros a1 l1 l2; simpl; rewrite (flat_map_app l1 l2); rewrite ass_app; apply eq_refl.
@@ -368,7 +368,7 @@ Qed.
 Lemma nth_error_none :
    forall A n (l : list A) , nth_error l n = None -> length l <= n.
 Proof.
-fix 3.
+fix nth_error_none 3.
 intros A n [ | a l]; case n; clear n; simpl.
 intros _; apply le_n.
 intros; apply le_O_n.
@@ -383,7 +383,7 @@ Lemma nth_error_almost_id :
 	nth_error (l ++ a1 :: l') n = nth_error (l ++ a2 :: l') n \/
 	(nth_error (l ++ a1 :: l') n = Some a1 /\ nth_error (l ++ a2 :: l') n = Some a2).
 Proof.
-fix 2.
+fix nth_error_almost_id 2.
 intros A [ | n] l l' a1 a2; case l; clear l; simpl.
 right; split; reflexivity.
 intro a; left; reflexivity.
@@ -424,7 +424,7 @@ Lemma list_eq_bool_ok :
   match list_eq_bool eq_bool l1 l2 with true => l1 = l2 | false => l1 <> l2 end.
 Proof.
 intros A eq_bool eq_bool_ok.
-fix 1; intro l1; case l1; clear l1; [idtac | intros a1 l1]; (intro l2; case l2; clear l2; [idtac | intros a2 l2]).
+fix list_eq_bool_ok 1; intro l1; case l1; clear l1; [idtac | intros a1 l1]; (intro l2; case l2; clear l2; [idtac | intros a2 l2]).
 simpl; reflexivity.
 simpl; discriminate.
 simpl; discriminate.
@@ -450,7 +450,7 @@ Fixpoint mem (e : A) (l : list A) {struct l} : Prop :=
 Lemma mem_eq_mem :
   equivalence _ eqA -> forall a a' l, eqA a a' -> mem a l -> mem a' l.
 Proof.
-intros E a a'; fix 1.
+intros E a a'; fix mem_eq_mem 1.
 intro l; case l; clear l.
 intros _ a_mem_nil; contradiction.
 intros b l a_eq_a' H; simpl in H; case H; clear H; [intro a_eq_b | intro a_mem_l].
@@ -463,7 +463,7 @@ Qed.
 Lemma mem_in_eq :
   forall a l, mem a l <-> (exists a', eqA a a' /\ In a' l).
 Proof.
-fix 2.
+fix mem_in_eq 2.
 intros a l; case l; clear l; simpl.
 split.
 intro; contradiction.
@@ -485,7 +485,7 @@ Qed.
 
 Lemma mem_impl_in : (forall a b, eqA a b -> a = b) -> forall e l, mem e l -> In e l.
 Proof.
-fix 3.
+fix mem_impl_in 3.
 intros eq_is_eq e l; case l; clear l.
 intro e_mem_nil; contradiction.
 simpl; intros a l [e_eq_a | e_mem_l].
@@ -501,7 +501,7 @@ end.
 
 Lemma mem_bool_ok  : forall a l, match mem_bool a l with true => mem a l | false => ~mem a l end.
 Proof.
-fix 2.
+fix mem_bool_ok 2.
 intros a l; case l; simpl.
 intro F; assumption.
 intros b k; generalize (eq_bool_ok a b); case (eq_bool a b).
@@ -515,7 +515,7 @@ Defined.
 
 Lemma mem_bool_app : forall a l1 l2, mem_bool a (l1 ++ l2) = orb (mem_bool a l1) (mem_bool a l2).
 Proof.
-fix 2.
+fix mem_bool_app 2.
 intros a l1; case l1; clear l1.
 intros l2; reflexivity.
 simpl; intros a1 l1 l2; rewrite mem_bool_app; rewrite orb_assoc; reflexivity.
@@ -635,7 +635,7 @@ Lemma included_list_sound :
   forall l1 l2, (included_list l1 l2 = true) -> forall x, mem x l1 -> mem x l2.
 Proof.
   intro eq_trans.
-  fix 1.
+  fix included_list_sound 1.
   intros l1 l2;case l1.
 
   intros _ x abs;elim abs.
@@ -665,7 +665,7 @@ Function find (B : Type) (a : A) (l : list (A * B)) {struct l} : option B :=
 Lemma eq_find_eq : equivalence _ eqA -> forall B a a' l, eq_bool a a'  = true -> find (B := B) a l = find a' l.
 Proof.
 intro eq_proof.
-fix 4.
+fix eq_find_eq 4.
 intros B a a' l; case l; clear l; simpl.
 intros _; reflexivity.
 intros p l; case p; clear p; simpl.
@@ -690,7 +690,7 @@ Lemma find_diff :
      forall (B : Type) a1 a2, eq_bool a2 a1 = false -> 
      forall l1 l2 b, find a2 (l1 ++ (a1,b) :: l2) = find (B:= B) a2 (l1 ++ l2).
 Proof.
-fix 5.
+fix find_diff 5.
 intros B a1 a2 a2_diff_a1 l1; case l1; clear l1; simpl.
 revert a2_diff_a1; generalize (eq_bool_ok a2 a1); case (eq_bool a2 a1).
 intros _ Abs; discriminate.
@@ -705,7 +705,7 @@ Lemma find_mem :
    forall (B : Type)  (a : A)  (l : list (A * B)) (b : B),
   find a l = Some b -> {a' : A & {l1 : list (A * B) & {l2 : list (A * B) | eqA a a' /\ l = l1 ++ (a',b) :: l2 } } }.
 Proof.
-fix 3.
+fix find_mem 3.
 intros B a l b; case l; clear l; simpl. 
 intro Abs; discriminate.
 intros p l; case p; clear p; intros a1 b1.
@@ -740,7 +740,7 @@ Qed.
 Lemma find_not_found : 
   forall (B : Type) (a a' : A) (b : B) (l : list (A * B)), find a l = None -> eq_bool a a' = true -> ~In (a',b) l.
 Proof.
-fix 5.
+fix find_not_found 5.
 intros B a a' b l; case l; clear l.
 intros _ _ Abs; contradiction.
 intros p l; case p; clear p; intros a1 b1; simpl.
@@ -757,7 +757,7 @@ Lemma find_app :
   find a (l1 ++ l2) =
      if mem_bool a (map (fun st => fst st) l1) then find a l1 else find a l2.  
 Proof.
-fix 3.
+fix find_app 3.
 intros B a l1; case l1; clear l1; simpl.
 intros l2; reflexivity.
 intros p l1 l2; case p; clear p; intros a1 b1; simpl.
@@ -774,7 +774,7 @@ Lemma find_map :
    | None => find a (map (fun xval : A * B => (fst xval, f (snd xval))) l) = None
    end.
 Proof.
-fix 5.
+fix find_map 5.
 intros B C  f a l; case l; clear l; simpl.
 reflexivity.
 intros p l; case p; clear p; intros a1 b1; simpl.
@@ -826,7 +826,7 @@ Lemma merge_correct :
                                                   eq_bool a a' = true /\ eqB_bool b2 b1 = false
         end.
 Proof.
-intros eq_proof RB; fix 2.
+intros eq_proof RB; fix merge_correct 2.
 intros l1 l2; case l2; clear l2; simpl.
 (* 1/2 l2 = [] *)
 repeat split.
@@ -951,7 +951,7 @@ Lemma merge_inv :
        | None => True
        end.
 Proof.
-intros eq_proof RB; fix 2.
+intros eq_proof RB; fix merge_inv 2.
 intros l1 l2; case l2; clear l2.
 (* 1/2 l2 = [] *)
 intros Inv1 _; exact Inv1.
@@ -1003,7 +1003,7 @@ Lemma nb_occ_app :
   forall (B : Type) a (l1 l2 : list (A * B)), 
   nb_occ a (l1++l2) = nb_occ a l1 + nb_occ a l2.
 Proof.
-fix 3.
+fix nb_occ_app 3.
 intros B a l1; case l1; clear l1; simpl.
 intros l2; reflexivity.
 intros p l1 l2; case p; clear p; intros a1 _; simpl.
@@ -1015,7 +1015,7 @@ Qed.
 Lemma none_nb_occ_O :
   forall (B : Type) (a : A) (l : list (A * B)), find a l = None -> nb_occ a l = 0.
 Proof.
-fix 3.
+fix none_nb_occ_O 3.
 intros B a l; case l; clear l; simpl.
 intros _; reflexivity.
 intros p l; case p; clear p; intros a1 b1; simpl.
@@ -1027,7 +1027,7 @@ Qed.
 Lemma some_nb_occ_Sn :
   forall (B : Type) (a : A) (l : list (A * B)) b, find a l = Some b -> 1 <= nb_occ a l.
 Proof.
-fix 3.
+fix some_nb_occ_Sn 3.
 intros B a l; case l; clear l; simpl.
 intros b Abs; discriminate.
 intros p l b; case p; clear p; simpl.
@@ -1041,7 +1041,7 @@ Lemma reduce_assoc_list :
   forall (B : Type) (l : list (A * B)),  {l' : list (A * B) | (forall a, nb_occ a l' <= 1) /\ (forall a, find a l = find a l')}.
 Proof.
 intro eq_proof.
-fix 2.
+fix reduce_assoc_list 2.
 intros B l; case l; clear l; simpl.
 exists (nil : list (A * B)); simpl; split.
 intros _; apply le_O_n.
@@ -1140,7 +1140,7 @@ Lemma list_forall_is_sound :
   list_forall P_bool l = true <-> 
   (forall a, In a l -> P_bool a = true).
 Proof.
-fix 3.
+fix list_forall_is_sound 3.
 intros A P_bool l; case l; clear l; simpl.
 split.
 intros _ a Abs; contradiction.
@@ -1724,7 +1724,7 @@ Lemma prop_map_without_repetition :
    end) ->
    (forall b, In b (map_without_repetition eq_bool f l) -> P b).
 Proof.
-intros A B eq_bool eq_bool_ok P f; fix 1; intro l; case l; clear l; simpl.
+intros A B eq_bool eq_bool_ok P f; fix prop_map_without_repetition 1; intro l; case l; clear l; simpl.
 (* 1/2 l = nil *)
 intros _ b b_in_nil; contradiction.
 (* 1/1 l = _ :: _ *)
@@ -1756,7 +1756,7 @@ Lemma exists_map_without_repetition :
                         end) ->
   (exists b, In b (map_without_repetition eq_bool f l) /\ P b).
 Proof.
-intros A B eq_bool eq_bool_ok P f; fix 1; intro l; case l; clear l; simpl.
+intros A B eq_bool eq_bool_ok P f; fix exists_map_without_repetition 1; intro l; case l; clear l; simpl.
 (* 1/2 l = nil *)
 intros [a [F _]]; contradiction.
 (* 1/1 l = _ :: _ *)
@@ -1829,7 +1829,7 @@ Lemma prop_map12_without_repetition :
    end) ->
  (forall d, In d (map12_without_repetition eq_bool f l) -> P d).
 Proof.
-intros A B eq_bool eq_bool_ok P f; fix 1; intro l; case l; clear l.
+intros A B eq_bool eq_bool_ok P f; fix prop_map12_without_repetition 1; intro l; case l; clear l.
 (* 1/2 l = nil *)
 intros _ b b_in_nil; contradiction.
 (* 1/1 l = _ :: _ *)
@@ -1877,7 +1877,7 @@ Lemma exists_map12_without_repetition :
                         end) ->
   (exists d, In d (map12_without_repetition eq_bool f l) /\ P d)).
 Proof.
-intros A B eq_bool eq_bool_ok P f; fix 1; intro l; case l; clear l.
+intros A B eq_bool eq_bool_ok P f; fix exists_map12_without_repetition 1; intro l; case l; clear l.
 (* 1/2 l = nil *)
 intros [a [a_in_nil _]]; contradiction.
 (* 1/1 l = _ :: _ *)

--- a/Coccinelle/list_extensions/weaved_relation.v
+++ b/Coccinelle/list_extensions/weaved_relation.v
@@ -28,7 +28,7 @@ Lemma one_step_list_incl :
   forall l1 l2, one_step_list R1 l1 l2 -> one_step_list R2 l1 l2.
 Proof.
 intros A R1 R2 R1_in_R2.
-fix 1.
+fix one_step_list_incl 1.
 intros l1; case l1; clear l1.
 intros l2 H; inversion H.
 intros a1 l1 l2 H; inversion H as [b1 b2 l H1 | b k1 k2 Hk]; subst.
@@ -39,7 +39,7 @@ Qed.
 Lemma one_step_list_length_eq :
   forall A R (l1 l2 : list A), one_step_list R l1 l2 -> length l1 = length l2.
 Proof.
-intros A R; fix 1.
+intros A R; fix one_step_list_length_eq 1.
 intros l1; case l1; clear l1.
 intros l2 H; inversion H.
 intros a1 l1 l2 H; inversion H as [b1 b2 l H1 | b k1 k2 Hk]; subst.
@@ -66,7 +66,7 @@ Qed.
 Lemma acc_one_step_list_1 :
   forall A R (l : list A), (forall t, In t l -> Acc R t) -> Acc (one_step_list R) l.
 Proof.
-fix 3.
+fix acc_one_step_list_1 3.
 intros A R l; case l; clear l.
 intros _; apply Acc_intro; intros l' H; inversion H.
 intros a l Acc_l.
@@ -88,7 +88,7 @@ Qed.
 Lemma acc_one_step_list_2 :
  forall A R (l : list A), Acc (one_step_list R) l -> (forall t, In t l -> Acc R t). 
 Proof.
-fix 4.
+fix acc_one_step_list_2 4.
 intros A R l Acc_l t t_in_l; apply Acc_intro; intros s H.
 destruct (in_split t l t_in_l) as [l1 [l2 K]].
 apply (acc_one_step_list_2 A R (l1 ++ s :: l2)).
@@ -121,7 +121,7 @@ Qed.
 Lemma one_step_list_chop : 
   forall A R (k1 l1 k2 l2 : list A), length k1 = length k2 -> one_step_list R (k1 ++ l1) (k2 ++ l2) -> refl_trans_clos (one_step_list R) l1 l2.
 Proof.
-fix 3.
+fix one_step_list_chop 3.
 intros A R k1 l1 k2 l2 L H.
 destruct k1 as [ | a k1]; destruct k2 as [ | b k2].
 right; left; assumption.

--- a/Coccinelle/term_algebra/equational_theory.v
+++ b/Coccinelle/term_algebra/equational_theory.v
@@ -1082,7 +1082,7 @@ Qed.
 
   Lemma maxl_is_max : forall (A : Type) l n a, In (n,a) l -> n <= maxl A l.
   Proof.
-    fix 2.
+    fix maxl_is_max 2.
     intros A l; case l; clear l.
     intros; contradiction.
     simpl; intros na1 l.
@@ -1101,7 +1101,7 @@ Qed.
     end.
 
   Lemma maxll_is_max : forall (A : Type) ll l, In l ll -> forall n a, In (n,a) l -> n <= maxll A ll.
-    fix 2.
+    fix maxll_is_max 2.
     intros A ll; case ll; clear ll.
     intros; contradiction.
     simpl; intros l1 ll.
@@ -1138,7 +1138,7 @@ Qed.
       find X.eq_bool v (map (fun xt => (inject (fst xt), f xt)) sigma) =
       find beq_nat (inject_inv v) (map (fun xt => (fst xt, f xt)) sigma).
     Proof.
-      fix 5.
+      fix find_inject 5.
       intros C B v f sigma; case sigma; clear sigma.
       apply eq_refl.
       intros p l; case p; clear p.

--- a/Coccinelle/term_algebra/term.v
+++ b/Coccinelle/term_algebra/term.v
@@ -95,7 +95,7 @@ Proof.
 intro t; case t; clear t.
 intro v; reflexivity.
 intros f l; simpl; apply f_equal.
-revert l; fix 1.
+revert l; fix size_unfold 1.
 intro l; case l; clear l.
 reflexivity.
 intros t l; simpl; rewrite size_unfold; reflexivity.
@@ -150,14 +150,14 @@ Function var_list_list (l : list term) {struct l} : list variable :=
 
 Lemma var_list_list_app : forall l1 l2, var_list_list (l1 ++ l2) = (var_list_list l1) ++ var_list_list l2.
 Proof.
-fix 1; intros l1 l2; case l1; clear l1.
+fix var_list_list_app 1; intros l1 l2; case l1; clear l1.
 reflexivity.
 intros t1 l1; simpl; rewrite <- ass_app; rewrite var_list_list_app; reflexivity.
 Qed.
 
 Lemma in_var_list_list : forall l v, In v (var_list_list l) -> exists t, In t l /\ In v (var_list t).
 Proof.
-fix 1; intro l; case l; clear l.
+fix in_var_list_list 1; intro l; case l; clear l.
 intros v v_in_nil; contradiction.
 simpl; intros t l v v_in_tl; destruct (in_app_or _ _ _ v_in_tl) as [v_in_t | v_in_l].
 exists t; split; [left; apply eq_refl | assumption].
@@ -167,7 +167,7 @@ Qed.
 
 Lemma mem_var_list_list : forall l v, mem (@eq _) v (var_list_list l) -> exists t, In t l /\ mem (@eq _) v (var_list t).
 Proof.
-fix 1; intro l; case l; clear l.
+fix mem_var_list_list 1; intro l; case l; clear l.
 intros v v_in_nil; contradiction.
 simpl; intros t l v v_in_tl; rewrite <- mem_or_app in v_in_tl; destruct v_in_tl as [v_in_t | v_in_l].
 exists t; split; [left; apply eq_refl | assumption].
@@ -232,7 +232,7 @@ Proof.
 intros t1 t2; unfold direct_subterm; case t2; clear t2.
 intros a Abs; elim Abs.
 intros f l; rewrite (size_unfold (Term f l)).
-revert t1 l; clear f; fix 2.
+revert t1 l; clear f; fix size_direct_subterm 2.
 intros t1 l; case l; clear l; simpl.
 intro Abs; elim Abs.
 intros t l t1_in_tl; case t1_in_tl; clear t1_in_tl.
@@ -282,14 +282,14 @@ Function symb_list_list (l : list term) {struct l} : list symbol :=
 
 Lemma symb_list_list_app : forall l1 l2, symb_list_list (l1 ++ l2) = (symb_list_list l1) ++ symb_list_list l2.
 Proof.
-fix 1; intros l1 l2; case l1; clear l1.
+fix symb_list_list_app 1; intros l1 l2; case l1; clear l1.
 reflexivity.
 intros t1 l1; simpl; rewrite <- ass_app; rewrite symb_list_list_app; reflexivity.
 Qed.
 
 Lemma in_symb_list_list : forall l f, In f (symb_list_list l) -> exists t, In t l /\ In f (symb_list t).
 Proof.
-fix 1; intro l; case l; clear l.
+fix in_symb_list_list 1; intro l; case l; clear l.
 intros v v_in_nil; contradiction.
 simpl; intros t l v v_in_tl; destruct (in_app_or _ _ _ v_in_tl) as [v_in_t | v_in_l].
 exists t; split; [left; apply eq_refl | assumption].
@@ -310,7 +310,7 @@ Lemma symb_in_term_list_app :
   forall f l1 l2, symb_in_term_list f (l1 ++ l2) = 
                      orb (symb_in_term_list f l1) (symb_in_term_list f l2).
 Proof.
-fix 2.
+fix symb_in_term_list_app 2.
 intros f l1 l2; case l1; clear l1; simpl.
 reflexivity.
 intros t l1; rewrite <- Bool.orb_assoc.
@@ -324,7 +324,7 @@ Proof.
 intros f l s g s_in_l g_in_s; rewrite symb_in_term_unfold.
 case (eq_symb_bool g f).
 reflexivity.
-simpl; revert l s_in_l; fix 1.
+simpl; revert l s_in_l; fix symb_in_direct_subterm 1.
 intro l; case l; clear l.
 intro Abs; elim Abs.
 simpl In; intros t l s_in_tl; case s_in_tl; clear s_in_tl.
@@ -355,7 +355,7 @@ Fixpoint eq_bool (t1 t2 :term) : bool :=
    end.
 
 Lemma eq_bool_ok : forall t1 t2, match eq_bool t1 t2 with true => t1 = t2 | false => t1<> t2 end.
-fix 1.
+fix eq_bool_ok0 1.
 intro t1; case t1; [intro v1 | intros f1 l1]; (intro t2; case t2; [intro v2 | intros f2 l2]); simpl.
 generalize (X.eq_bool_ok v1 v2); case (eq_var_bool v1 v2).
 intros v1_eq_v2; rewrite v1_eq_v2; reflexivity.
@@ -489,7 +489,7 @@ Definition term_rec3 :
 Proof.
 
 intros Hv Halg. 
-fix 1.
+fix term_rec3 1.
 intro t;case t.
 exact Hv.
 intro a.
@@ -710,7 +710,7 @@ Lemma subst_comp_is_subst_comp_aux2 :
   | None => find eq_var_bool v sigma2
   end.
 Proof.
-fix 2.
+fix subst_comp_is_subst_comp_aux2 2.
 intros v sigma1 sigma2; case sigma1; clear sigma1.
 reflexivity.
 intros p sigma; case p; clear p; intros v1 a1; simpl.
@@ -975,7 +975,7 @@ Qed.
 Lemma subterm_at_pos_dec :
   forall t s, {p : list nat | subterm_at_pos t p = Some s}+{forall p, subterm_at_pos t p <> Some s}.
 Proof.
-fix 1.
+fix subterm_at_pos_dec 1.
 intros t; case t; clear t.
 intros x s; case s; clear s; [intro x'| intros f' l'].
 generalize (X.eq_bool_ok x x'); case (eq_var_bool x x').
@@ -1007,7 +1007,7 @@ intro t_in_l; exact t_in_l.
 assert (IH' : forall s, {n :nat & {t : term & {p | (nth_error l n) = Some t /\ subterm_at_pos t p = Some s}}} + 
                         {(forall t, In t l -> forall p, subterm_at_pos t p <> Some s)}).
 clear -IH.
-revert l IH; fix 1.
+revert l IH; fix subterm_at_pos_dec 1.
 intro l; case l; clear l.
 intros _ s; right; intros t Abs; elim Abs.
 intros t l IH s.
@@ -1158,7 +1158,7 @@ Qed.
 Lemma symb_in_subterm :
   forall f s t p, subterm_at_pos t p = Some s -> symb_in_term f s = true -> symb_in_term f t = true.
 Proof.
-fix 4.
+fix symb_in_subterm 4.
 intros f s t p; case p; clear p; simpl.
 intro H; injection H; clear H; intro H; rewrite H; intro H'; exact H'.
 intros n p; case t; clear t.
@@ -1241,7 +1241,7 @@ Qed.
 Lemma well_formed_subterm :
   forall t p s, well_formed t -> subterm_at_pos t p = Some s -> well_formed s.
 Proof.
-fix 2; intros t p; case p; clear p.
+fix well_formed_subterm 2; intros t p; case p; clear p.
 intros s Wt Sub; injection Sub; intros; subst; assumption.
 intros i p s; simpl; case t; clear t.
 intros; discriminate.
@@ -1534,7 +1534,7 @@ Lemma remove_garbage_subst :
                                      sigma' = tau ++ (x,val) :: tau' ++ (y,val') :: tau'' ->
                                      x <> y)}.
 Proof.
-fix 1.
+fix remove_garbage_subst 1.
 intro sigma; case sigma; clear sigma.
 exists nil; repeat split.
 intros x val Abs; elim Abs.
@@ -1655,7 +1655,7 @@ end.
 Lemma subst_rest_ok :
   forall vars sigma v, In v vars -> apply_subst (subst_rest vars sigma) (Var v) = apply_subst sigma (Var v).
 Proof.
-fix 2.
+fix subst_rest_ok 2.
 intros vars sigma; case sigma; clear sigma.
 intros v _; apply eq_refl.
 intros p sigma; case p; clear p.
@@ -1676,7 +1676,7 @@ Qed.
 Lemma subst_rest_rest :
   forall vars sigma v t, In (v,t) (subst_rest vars sigma) -> In v vars.
 Proof.
-fix 2.
+fix subst_rest_rest 2.
 intros vars sigma; case sigma; clear sigma.
 intros v t; contradiction.
 intros p sigma; case p; clear p.
@@ -1695,7 +1695,7 @@ Qed.
 Lemma subst_rest_subst :
   forall vars sigma v t, In (v,t) (subst_rest vars sigma) -> In (v,t) sigma.
 Proof.
-fix 2.
+fix subst_rest_subst 2.
 intros vars sigma; case sigma; clear sigma.
 intros v t; contradiction.
 intros p sigma; case p; clear p.
@@ -1712,7 +1712,7 @@ Qed.
 Lemma subst_rest_subst_rest :
   forall vars sigma v t, In v vars -> In (v,t) sigma -> In (v,t) (subst_rest vars sigma).
 Proof.
-fix 2; intros vars sigma; case sigma; clear sigma.
+fix subst_rest_subst_rest 2; intros vars sigma; case sigma; clear sigma.
 intros; contradiction.
 intros p sigma; case p; clear p.
 simpl; intros x u v t x_in_vars.

--- a/Coccinelle/term_orderings/interp.v
+++ b/Coccinelle/term_orderings/interp.v
@@ -78,7 +78,7 @@ Module Interp(EQT:equational_theory_spec.EqTh).
 
    Definition measure : term -> A. 
    Proof.
-     fix 1.
+     fix measure 1.
      intros [a | f l].
      exact A0.
      assert (f_pol := Pols f).
@@ -148,7 +148,7 @@ Module Interp(EQT:equational_theory_spec.EqTh).
 
    Lemma measure_bounded : forall t, A0 <= measure t.
    Proof.
-     fix 1.
+     fix measure_bounded 1.
      intros [a | f l].
      simpl.
      apply Aop.(le_refl).
@@ -277,7 +277,7 @@ Lemma measure_monotonic :
 
    Definition marked_measure : term -> A.
    Proof.
-     fix 1.
+     fix marked_measure 1.
      intros [a|f l].
      exact (measure (Var a)).
      case (defined_dec f).

--- a/Coccinelle/term_orderings/isubterm_dp.v
+++ b/Coccinelle/term_orderings/isubterm_dp.v
@@ -136,7 +136,7 @@ right; left; reflexivity.
 assert (Abs := le_S_n _ _ (le_S_n _ _ P_ok)); inversion Abs.
 rewrite <- L in P_ok; generalize P_ok.
 simpl; set (k := map (apply_subst sigma) k1); clearbody k; set (p := P f); clearbody p.
-revert p k; fix 1.
+revert p k; fix projection_is_subterm 1.
 intro p; case p; clear p.
 intro l; case l; clear l.
 intro Abs; inversion Abs.

--- a/Coccinelle/term_orderings/matrix.v
+++ b/Coccinelle/term_orderings/matrix.v
@@ -134,7 +134,7 @@ Section Definitions.
       dim v, P dim v.
   Proof.
     intros P f1 f2.
-    fix 1;intros [|dim].
+    fix vector_rect 1;intros [|dim].
     exact f1.
     simpl.
     intros [a v].
@@ -166,7 +166,7 @@ Section Definitions.
   Definition eq_vec {dim} : vector dim -> vector dim -> Prop.
   Proof.
     revert dim.
-    fix 1.
+    fix eq_vec 1.
     intros [|dim].
     simpl; exact eq.
     simpl.
@@ -240,7 +240,7 @@ Section Definitions.
   
   Definition sum_vector : forall dim (v1 v2: vector dim), vector dim.
   Proof.
-    fix 1.
+    fix sum_vector 1.
     intros [|dim].
 
     simpl;  intros a b;exact (plus a b).
@@ -272,7 +272,7 @@ Section Definitions.
     forall (dim:nat) (v1 v2: vector dim), 
       sum_vector _ v1 v2 ==v sum_vector _ v2 v1.
   Proof.
-    fix 1.
+    fix sum_vector_comm 1.
     intros [|dim].
     simpl.
     intros v1 v2.
@@ -290,7 +290,7 @@ Section Definitions.
       sum_vector _ (sum_vector _ v1 v2) v3 ==v
       sum_vector _ v1 (sum_vector _ v2 v3).
   Proof.
-    fix 1.
+    fix sum_vector_assoc 1.
     intros [|dim].
     simpl.
     intros v1 v2 v3.
@@ -309,7 +309,7 @@ Section Definitions.
     forall dim (a:A)(v:vector dim), 
       vector dim.
   Proof.
-    fix 1.
+    fix prod_scal_vec 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -342,7 +342,7 @@ Section Definitions.
       prod_scal_vec _ (plus c1 c2) r ==v
       sum_vector _ (prod_scal_vec  dim c1 r) (prod_scal_vec _ c2 r).
   Proof.
-    fix 1.
+    fix psv_distrib_left 1.
     intros [|dim].
     simpl. intros. 
     apply mult_distrib_left.
@@ -360,7 +360,7 @@ Section Definitions.
       prod_scal_vec _ c (sum_vector _ r1 r2)  ==v
       sum_vector _ (prod_scal_vec  dim c r1) (prod_scal_vec _ c r2).
   Proof.
-    fix 1.
+    fix psv_distrib_right 1.
     intros [|dim].
     simpl. intros. 
     apply mult_distrib_right.
@@ -378,7 +378,7 @@ Section Definitions.
       prod_scal_vec _ c1  (prod_scal_vec _  c2 r) ==v 
       prod_scal_vec _ (mult c1 c2) r .
   Proof.
-    fix 1.
+    fix psv_assoc 1.
     intros [|dim].
     simpl. intros. 
     symmetry; apply mult_assoc.
@@ -396,7 +396,7 @@ Section Definitions.
       prod_scal_vec _ a1 (prod_scal_vec _ a2 v) ==v
       prod_scal_vec _ a2 (prod_scal_vec _ a1 v).
   Proof.
-    fix 1.
+    fix psv_comm 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -421,7 +421,7 @@ Section Definitions.
   Definition prod_row_col : 
     forall dim (v1 v2:vector dim), A.
   Proof.
-    fix 1.
+    fix prod_row_col 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -451,7 +451,7 @@ Section Definitions.
       prod_row_col _ r (prod_scal_vec _ a c) ==
       mult a  (prod_row_col _ r c).
   Proof.
-    fix 1.
+    fix prc_comm_sv_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -475,7 +475,7 @@ Section Definitions.
       prod_row_col _ (prod_scal_vec _ a r) c ==
       mult a  (prod_row_col _ r c).
   Proof.
-    fix 1.
+    fix prc_comm_sv_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -496,7 +496,7 @@ Section Definitions.
       prod_row_col _ (sum_vector _ c1  c2) r ==
       plus (prod_row_col  dim c1 r) (prod_row_col _ c2 r).
   Proof.
-    fix 1.
+    fix prc_distrib_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -527,7 +527,7 @@ Section Definitions.
       prod_row_col _ c (sum_vector _ r1  r2) ==
       plus (prod_row_col  dim c r1) (prod_row_col _ c r2).
   Proof.
-    fix 1.
+    fix prc_distrib_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -582,7 +582,7 @@ Section Definitions.
       dim m, P dim m.
   Proof.
     intros P f1 f2.
-    fix 1;intros [|dim].
+    fix matrix_rect 1;intros [|dim].
     exact f1.
     simpl.
     intros [a [r [c v]]].
@@ -612,7 +612,7 @@ Section Definitions.
 
   Definition eq_mat {dim} : matrix dim -> matrix dim -> Prop.
   Proof.
-    revert dim. fix 1.
+    revert dim. fix eq_mat 1.
     intros [|dim].
     simpl; exact eq.
     simpl.
@@ -695,7 +695,7 @@ Section Definitions.
 
   Definition sum_matrix : forall dim (m1 m2:matrix dim), matrix dim.
   Proof.
-    fix 1.
+    fix sum_matrix 1.
     intros [|dim].
     simpl.
     intros a b;exact (plus a b).
@@ -729,7 +729,7 @@ Section Definitions.
   Lemma sum_matrix_comm : 
     forall dim m1 m2, sum_matrix dim m1 m2 ==m sum_matrix dim m2 m1.
   Proof.
-    fix 1.
+    fix sum_matrix_comm 1.
     intros [|dim]. 
     (* dim = 0 *) 
     simpl; apply plus_comm.
@@ -750,7 +750,7 @@ Section Definitions.
       sum_matrix dim (sum_matrix _ m1 m2) m3 ==m 
       sum_matrix dim m1 (sum_matrix _ m2 m3).
   Proof.
-    fix 1.
+    fix sum_matrix_assoc 1.
     intros [|dim]. 
     (* dim = 0 *) 
     simpl; apply plus_assoc.
@@ -771,7 +771,7 @@ Section Definitions.
     forall dim (a:A)(v:matrix dim), 
       matrix dim.
   Proof.
-    fix 1.
+    fix prod_scal_mat 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -811,7 +811,7 @@ Section Definitions.
       (prod_scal_mat  dim c1 m)
       (prod_scal_mat _ c2 m).
   Proof.
-    fix 1.
+    fix psm_distrib_left 1.
     intros [|dim].
     simpl. intros. 
     apply mult_distrib_left.
@@ -831,7 +831,7 @@ Section Definitions.
       prod_scal_mat _ c (sum_matrix _ r1 r2) ==m 
       sum_matrix _ (prod_scal_mat  dim c r1) (prod_scal_mat _ c r2).
   Proof.
-    fix 1.
+    fix psm_distrib_right 1.
     intros [|dim].
     simpl. intros. 
     apply mult_distrib_right.
@@ -851,7 +851,7 @@ Section Definitions.
       prod_scal_mat _ c1  (prod_scal_mat _  c2 r) ==m 
       prod_scal_mat _ (mult c1 c2) r .
   Proof.
-    fix 1.
+    fix psm_assoc 1.
     intros [|dim].
     simpl. intros. 
     symmetry; apply mult_assoc.
@@ -871,7 +871,7 @@ Section Definitions.
       prod_scal_mat _ a1 (prod_scal_mat _ a2 v) ==m 
       prod_scal_mat _ a2 (prod_scal_mat _ a1 v).
   Proof.
-    fix 1.
+    fix psm_comm 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -896,7 +896,7 @@ Section Definitions.
   (* product of a col by a row *)
   Definition prod_col_row : forall (dim:nat) (c r:vector dim), matrix dim.
   Proof.
-    fix 1.
+    fix prod_col_row 1.
     intros [|dim].
     simpl.
     intros a b;exact (mult a b).
@@ -931,7 +931,7 @@ Section Definitions.
       prod_col_row _ c (prod_scal_vec _ a r) ==m 
       prod_scal_mat _ a  (prod_col_row _ c r).
   Proof.
-    fix 1.
+    fix pcr_comm_sv_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -958,7 +958,7 @@ Section Definitions.
       prod_col_row _ (prod_scal_vec _ a r) c ==m
       prod_scal_mat _ a  (prod_col_row _ r c).
   Proof.
-    fix 1.
+    fix pcr_comm_sv_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl.
@@ -984,7 +984,7 @@ Section Definitions.
       sum_matrix _
       (prod_col_row dim c1 r) (prod_col_row _ c2 r).
   Proof.
-    fix 1.
+    fix pcr_distrib_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1005,7 +1005,7 @@ Section Definitions.
       prod_col_row _ c (sum_vector _ r1  r2) ==m
       sum_matrix _ (prod_col_row  dim c r1) (prod_col_row _ c r2).
   Proof.
-    fix 1.
+    fix pcr_distrib_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1025,7 +1025,7 @@ Section Definitions.
   
   Definition prod_row_mat : forall (dim:nat) (r:vector dim)  (m:matrix dim), vector dim.
   Proof.
-    fix 1.
+    fix prod_row_mat 1.
     intros [|dim].
     simpl.
     intros a b;exact (mult a b).
@@ -1060,7 +1060,7 @@ Section Definitions.
       prod_row_mat _ r (prod_scal_mat _ a m) ==v 
       prod_scal_vec _ a  (prod_row_mat _ r m).
   Proof.
-    fix 1.
+    fix prm_comm_sv_right 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1092,7 +1092,7 @@ Section Definitions.
       prod_row_mat _ (prod_scal_vec _ a r) m ==v
       prod_scal_vec _ a  (prod_row_mat _ r m).
   Proof.
-    fix 1.
+    fix prm_comm_sv_left 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1119,7 +1119,7 @@ Section Definitions.
       sum_vector _
       (prod_row_mat dim r1 m) (prod_row_mat _ r2 m).
   Proof.
-    fix 1.
+    fix prm_distrib_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1152,7 +1152,7 @@ Section Definitions.
       prod_row_mat _ r (sum_matrix _ m1  m2) ==v 
       sum_vector _ (prod_row_mat  dim r m1) (prod_row_mat _ r m2).
   Proof.
-    fix 1.
+    fix prm_distrib_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1181,7 +1181,7 @@ Section Definitions.
   
   Definition prod_mat_col : forall (dim:nat) (m:matrix dim) (c:vector dim), vector dim.
   Proof.
-    fix 1.
+    fix prod_mat_col 1.
     intros [|dim].
     simpl.
     intros a b;exact (mult a b).
@@ -1216,7 +1216,7 @@ Section Definitions.
       prod_mat_col _ m (prod_scal_vec _ a c) ==v 
       prod_scal_vec _ a  (prod_mat_col _ m c).
   Proof.
-    fix 1.
+    fix pmc_comm_sv_right 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1243,7 +1243,7 @@ Section Definitions.
       prod_mat_col _ (prod_scal_mat _ a m) c ==v 
       prod_scal_vec _ a  (prod_mat_col _ m c).
   Proof.
-    fix 1.
+    fix pmc_comm_sv_left 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1268,7 +1268,7 @@ Section Definitions.
       sum_vector _
       (prod_mat_col dim m1 c) (prod_mat_col _ m2 c).
   Proof.
-    fix 1.
+    fix pmc_distrib_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1297,7 +1297,7 @@ Section Definitions.
       prod_mat_col _ m (sum_vector _ c1  c2) ==v
       sum_vector _ (prod_mat_col  dim m c1) (prod_mat_col _ m c2).
   Proof.
-    fix 1.
+    fix pmc_distrib_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1327,7 +1327,7 @@ Section Definitions.
 
   Definition prod_matrix : forall (dim:nat) (m1 m2:matrix dim), matrix dim. 
   Proof.
-    fix 1.
+    fix prod_matrix 1.
     intros [|dim].
     intros a b;exact (mult a b).
 
@@ -1368,7 +1368,7 @@ Section Definitions.
       prod_matrix _ (prod_scal_mat _ a m1) m2 ==m
       prod_scal_mat _ a  (prod_matrix _ m1 m2).
   Proof.
-    fix 1.
+    fix pm_comm_sv_right 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1401,7 +1401,7 @@ Section Definitions.
       prod_matrix _ m1 (prod_scal_mat _ a m2) ==m
       prod_scal_mat _ a  (prod_matrix _ m1 m2).
   Proof.
-    fix 1.
+    fix pm_comm_sv_left 1.
     intros [|dim].
     (* dim = 0 *)
     simpl.
@@ -1440,7 +1440,7 @@ Section Definitions.
       sum_matrix _
       (prod_matrix dim m1 m3) (prod_matrix _ m2 m3).
   Proof.
-    fix 1.
+    fix pm_distrib_left 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1491,7 +1491,7 @@ Section Definitions.
       sum_matrix _
       (prod_matrix dim m1 m2) (prod_matrix _ m1 m3).
   Proof.
-    fix 1.
+    fix pm_distrib_right 1.
     intros [|dim].
         (* dim = 0 *)
     simpl. intros. 
@@ -1538,7 +1538,7 @@ Section Definitions.
       prod_row_col dim (prod_row_mat _ r m) c == 
       prod_row_col dim r (prod_mat_col _ m c).
   Proof.
-    fix 1.
+    fix prm_pmc_comm 1.
     intros [|dim].
     (* dim = 0 *)
     simpl;intros;apply mult_assoc.
@@ -1575,7 +1575,7 @@ Section Definitions.
       prod_mat_col dim (prod_col_row _ c1 r) c2 ==v  
       prod_scal_vec _ (prod_row_col _ r c2) c1.
   Proof.
-    fix 1.
+    fix pcr_prc_comm 1.
     intros [|dim].
     intros;simpl.
     rewrite (mult_comm c1).
@@ -1612,7 +1612,7 @@ Section Definitions.
     prod_mat_col dim m1 (prod_mat_col _ m2 c) ==v 
     prod_mat_col _ (prod_matrix _ m1 m2) c. 
   Proof.
-    fix 1.
+    fix pm_assoc_pmc 1.
     intros [|dim].
     (* dim = 0 *)
     intros;simpl.
@@ -1678,7 +1678,7 @@ Definition split_vector :
   forall A B dim,  vector (A * B) dim -> vector A dim * vector B dim.
 Proof.
   intros A B.
-  fix 1;intros [|dim].
+  fix split_vector 1;intros [|dim].
   simpl.
   intros res;exact res.
   simpl. 
@@ -1692,7 +1692,7 @@ Definition combine_vector :
   forall A B dim,   vector A dim  -> vector B dim -> vector (A * B) dim.
 Proof.
   intros A B.
-  fix 1;intros [|dim].
+  fix combine_vector 1;intros [|dim].
   simpl.
   intros a b;exact (a,b).
 
@@ -1733,7 +1733,7 @@ Definition matrix_from_vector_of_vectors : forall A dim, (vector (vector A dim) 
   matrix A dim.
 Proof.
   intros A. 
-  fix 1.
+  fix matrix_from_vector_of_vectors 1.
   intros [|dim].
   
   intros a;exact a.
@@ -1752,7 +1752,7 @@ Definition vector_of_vectors_from_matrix :
   forall A dim, matrix A dim -> vector (vector A dim) dim.
 Proof.
   intros A.
-  fix 1;intros [|dim].
+  fix vector_of_vectors_from_matrix 1;intros [|dim].
   intros a;exact a.
   simpl.
   intros [a [r [c m]]].
@@ -2706,7 +2706,7 @@ Module Make(R:TRing).
 
   Definition id_matrix : forall dim, matrix dim .
   Proof.
-    fix 1.
+    fix id_matrix 1.
     intros [|dim].
     exact rI.
     simpl.
@@ -2827,7 +2827,7 @@ Module Make_Ordered(R:Ordered_Ring).
 
   Definition vec_order_large : forall dim, vector dim -> vector dim -> Prop.
   Proof.
-    fix 1;intros [|dim].
+    fix vec_order_large 1;intros [|dim].
     exact le.
     simpl;intros [a1 v1] [a2 v2]. 
     refine (and _ _).
@@ -2837,7 +2837,7 @@ Module Make_Ordered(R:Ordered_Ring).
 
   Definition vec_order_strict : forall dim, vector dim -> vector dim -> Prop.
   Proof.
-    fix 1;intros [|dim].
+    fix vec_order_strict 1;intros [|dim].
     exact lt.
     simpl;intros [a1 v1] [a2 v2]. 
     refine (and _ _).
@@ -2993,7 +2993,7 @@ Module Make_Ordered(R:Ordered_Ring).
 
   Definition mat_order_large : forall dim, matrix dim -> matrix dim -> Prop.
   Proof.
-    fix 1;intros [|dim].
+    fix mat_order_large 1;intros [|dim].
     exact le.
     simpl;intros [a1 [l1 [c1 m1]]] [a2 [l2 [c2 m2]]]. 
     refine (and _ (and _ (and _ _))).
@@ -3005,7 +3005,7 @@ Module Make_Ordered(R:Ordered_Ring).
 
   Definition mat_order_strict : forall dim, matrix dim -> matrix dim -> Prop.
   Proof.
-    fix 1;intros [|dim].
+    fix mat_order_strict 1;intros [|dim].
     exact lt.
     simpl;intros [a1 [l1 [c1 m1]]] [a2 [l2 [c2 m2]]]. 
     refine (and _ (and _ (and _ _))).

--- a/Coccinelle/term_orderings/rpo.v
+++ b/Coccinelle/term_orderings/rpo.v
@@ -559,7 +559,7 @@ Lemma equiv_in_list :
       equiv (Term f l1) (Term g l2).
 Proof.
 intros f g f_stat g_stat l1 l2 L prec_eq_f_g E.  apply (Eq_lex f g f_stat g_stat prec_eq_f_g).
-clear f f_stat prec_eq_f_g; revert l1 l2 L E; fix 1; intro l1; case l1; clear l1.
+clear f f_stat prec_eq_f_g; revert l1 l2 L E; fix equiv_in_list 1; intro l1; case l1; clear l1.
 intros l2; case l2; clear l2.
 intros _ _; apply Eq_list_nil.
 intros a2 l2 L _; discriminate.

--- a/Coccinelle/term_orderings/subterm_dp.v
+++ b/Coccinelle/term_orderings/subterm_dp.v
@@ -135,7 +135,7 @@ right; left; reflexivity.
 assert (Abs := le_S_n _ _ (le_S_n _ _ P_ok)); inversion Abs.
 rewrite <- L in P_ok; generalize P_ok.
 simpl; set (k := map (apply_subst sigma) k1); clearbody k; set (p := P f); clearbody p.
-revert p k; fix 1.
+revert p k; fix projection_is_subterm 1.
 intro p; case p; clear p.
 intro l; case l; clear l.
 intro Abs; inversion Abs.

--- a/Coccinelle/term_orderings/term_o.v
+++ b/Coccinelle/term_orderings/term_o.v
@@ -235,7 +235,7 @@ absurd (f1 =f2); auto.
 intros H1 H2; absurd (f1 = f2); trivial; apply As.
 generalize (OF1.o_bool_ok f1 f2); rewrite H1; intro; assumption.
 generalize (OF1.o_bool_ok f2 f1); rewrite H2; intro; assumption.
-fix 1; intro l1; case l1; clear l1; [idtac | intros a1 l1].
+fix o_anti_sym 1; intro l1; case l1; clear l1; [idtac | intros a1 l1].
 intros l2 _; case l2; clear l2; [trivial | intros a2 l2]; intros; discriminate.
 intros l2; case l2; clear l2; [intros; discriminate | intros a2 l2 Hrec; simpl].
 generalize (T1.eq_bool_ok a1 a2); case (T1.eq_bool a1 a2); [intro a1_eq_a2 | intro a1_diff_a2];
@@ -263,7 +263,7 @@ intros f l l_le_l; simpl.
 generalize (F.Symb.eq_bool_ok f f); case (F.Symb.eq_bool f f); 
 [intros _ | intro f_diff_f; apply False_rect; apply f_diff_f; reflexivity].
 rewrite <- o_term_list_is_o_term_list; assumption.
-fix 1; intro l; case l; clear l.
+fix o_proof 1; intro l; case l; clear l.
 intros _; reflexivity.
 intros t l H; simpl.
 generalize (T1.eq_bool_ok t t); case (T1.eq_bool t t); [intros _ | intro t_diff_t; apply False_rect; apply t_diff_t; reflexivity].
@@ -308,7 +308,7 @@ reflexivity.
 apply False_rect; apply f1_not_le_f3; apply Ts with f2.
 generalize (OF1.o_bool_ok f1 f2); rewrite f1_le_f2; intro; assumption.
 generalize (OF1.o_bool_ok f2 f3); rewrite f2_le_f3; intro; assumption.
-fix 1; intro l1; case l1; clear l1.
+fix o_proof 1; intro l1; case l1; clear l1.
 intros _ l2; case l2; clear l2.
 intros l3; case l3; clear l3.
 intros _ _; reflexivity.

--- a/Coccinelle/unification/free_unif.v
+++ b/Coccinelle/unification/free_unif.v
@@ -770,7 +770,7 @@ Fixpoint lt_bool (n1 n2 : nat) {struct n1} :=
 
 Lemma lt_bool_ok : forall n1 n2, if lt_bool n1 n2 then n1 < n2 else ~n1 < n2.
 Proof.
-fix 1.
+fix lt_bool_ok 1.
 intro n1; case n1; clear n1.
 intros [ | n2]; simpl.
 apply lt_irrefl.
@@ -821,7 +821,7 @@ rewrite p2_lt_q2; trivial.
 generalize (lt_bool_ok p1 q1); case (lt_bool p1 q1).
 reflexivity.
 intro Abs; apply False_rect; apply p1_diff_q1.
-clear p1_diff_q1; revert p1 q1 p1_le_q1 Abs ; fix 1. 
+clear p1_diff_q1; revert p1 q1 p1_le_q1 Abs ; fix lex_le_lt 1. 
 intro p1; case p1; clear p1.
 intros q1 _; case q1; clear q1.
 intros _; reflexivity.
@@ -845,7 +845,7 @@ generalize (beq_nat_ok p1 q1); case (beq_nat p1 q1); [intro p1_eq_q1 | intro p1_
 generalize (lt_bool_ok p3 q3); case (lt_bool p3 q3).
 reflexivity.
 intro Abs; apply False_rect; apply Abs; assumption.
-revert p1 q1 p1_le_q1 p1_diff_q1 ; fix 1. 
+revert p1 q1 p1_le_q1 p1_diff_q1 ; fix lex_le_meq_lt 1. 
 intro p1; case p1; clear p1.
 intros q1 _; case q1; clear q1.
 intros Abs; apply False_rect; apply Abs; reflexivity.
@@ -1500,7 +1500,7 @@ intro Abs; apply False_rect; apply (lt_n_O _ Abs).
 intros n _; rewrite <- NatMul.LP.permut_cons_inside.
 rewrite <- NatMul.LP.permut_app2.
 clear l; revert x_not_in_dom_sig; unfold VSet.mem, DecVar.eq_A.
-generalize (VSet.support (domain_of_subst sigma)); fix 1.
+generalize (VSet.support (domain_of_subst sigma)); fix move_eq_decreases 1.
 intro l; case l; clear l.
 intros _; reflexivity.
 simpl; intros a l x_not_in_al.


### PR DESCRIPTION
Backward compatible fix for #6.