### PR TITLE
Minor cleaning

### DIFF
--- a/Conversion/ATerm_of_String.v
+++ b/Conversion/ATerm_of_String.v
@@ -10,13 +10,14 @@ convert a string into an algebraic term
 Set Implicit Arguments.
 
 From CoLoR Require Import LogicUtil RelUtil SN VecUtil ListUtil.
+From CoLoR Require Srs ATrs AUnary.
 
 Section S.
 
 (***********************************************************************)
 (** string signature *)
 
-From CoLoR Require Import Srs.
+Import Srs.
 
 Variable SSig : VSignature.Signature.
 
@@ -28,7 +29,7 @@ Notation srule := (rule SSig). Notation srules := (rules SSig).
 
 Definition ar (_ : letter) := 1.
 
-From CoLoR Require Import ATrs.
+Import ATrs.
 
 Definition ASig_of_SSig := mkSignature ar (@VSignature.beq_symb_ok SSig).
 
@@ -37,7 +38,7 @@ Notation ASig := ASig_of_SSig.
 Notation term := (term ASig). Notation terms := (vector term).
 Notation context := (context ASig).
 
-From CoLoR Require Import AUnary.
+Import AUnary.
 
 Lemma is_unary_sig : is_unary ASig.
 
@@ -75,7 +76,7 @@ induction s. refl. unfold reset. simpl. apply args_eq.
 fold (reset (term_of_string s)). rewrite IHs. refl.
 Qed.
 
-From CoLoR Require Import VecUtil.
+Import VecUtil.
 
 Fixpoint string_of_term (t : term) : string :=
   match t with
@@ -87,7 +88,7 @@ Lemma string_of_term_epi : forall s, string_of_term (term_of_string s) = s.
 
 Proof. induction s; simpl; intros. refl. rewrite IHs. refl. Qed.
 
-From CoLoR Require Import NatUtil.
+Import NatUtil.
 
 Lemma term_of_string_epi : forall t, maxvar t = 0 ->
   term_of_string (string_of_term t) = t.
@@ -319,7 +320,7 @@ End S.
 (***********************************************************************)
 (** signature functor *)
 
-Module Make (S : VSignature.FSIG) <: FSIG.
+Module Make (S : VSignature.FSIG) <: ASignature.FSIG.
   Definition Sig := ASig_of_SSig S.Sig.
   Definition Fs := S.Fs.
   Definition Fs_ok := S.Fs_ok.

--- a/Conversion/ATerm_of_String.v
+++ b/Conversion/ATerm_of_String.v
@@ -285,8 +285,8 @@ intro. rewrite WF_red_mod0; is_unary; preserve_vars.
 cut (forall s, SN (Srs.red_mod E R) s -> forall t, maxvar t = 0 ->
   t = term_of_string s -> SN (red_mod0 (trs_of_srs E) (trs_of_srs R)) t).
 (* cut correctness *)
-intros. intro t. destruct (eq_nat_dec (maxvar t) 0). Focus 2.
-apply SN_intro. intros. destruct H1. omega.
+intros. intro t. destruct (eq_nat_dec (maxvar t) 0).
+  2: apply SN_intro; intros ? []; omega.
 apply H0 with (string_of_term t). apply H. hyp. rewrite term_of_string_epi.
 refl. hyp.
 (* proof with cut *)

--- a/Term/SimpleType/TermsPos.v
+++ b/Term/SimpleType/TermsPos.v
@@ -59,7 +59,7 @@ Module TermsPos (Sig : TermsSig.Signature).
 
   Proof.
     intros M pos N.
-    destruct N as [N envN typeN termN].
+    destruct N as [N envN typeN].
     induction pos; simpl in * .
      (* PThis *)
     exists N; auto.

--- a/Term/SimpleType/TermsSubst.v
+++ b/Term/SimpleType/TermsSubst.v
@@ -46,7 +46,7 @@ Module TermsSubst (Sig : TermsSig.Signature).
 
   Proof.
     destruct (nth_error_In G x) as [[T Gx] | Gnx].
-    destruct T as [T | Gnx].
+    destruct T as [T | ].
     left; exists T; auto.
     right; auto with terms.
     right; auto with terms.

--- a/Term/WithArity/ACalls.v
+++ b/Term/WithArity/ACalls.v
@@ -147,7 +147,7 @@ ded (app_eq_nil _ _ H0). destruct H1.
 destruct H. subst x. hyp. apply IHv; hyp.
 Qed.
 
-From Coq Require Import Sumbool.
+Import Sumbool.
 
 Lemma in_calls : forall x t, In x (calls t)
   -> exists g, exists vs, x = Fun g vs /\ defined g R = true.

--- a/Term/WithArity/ACalls.v
+++ b/Term/WithArity/ACalls.v
@@ -52,14 +52,15 @@ Lemma defined_equiv : forall f R,
  defined f R = true <-> exists v, exists r, In (mkRule (Fun f v) r) R.
 
 Proof.
-intros. split. Focus 2.
-intro. destruct H as [v [r H]]. apply (lhs_fun_defined f v r). auto.
+intros. split.
+2: now intros [v [r H]]; apply (lhs_fun_defined f v r).
 intros. induction R. simpl in H. discr.
 simpl. simpl in H. destruct a as [a1 a2]. simpl in H. destruct a1.
 destruct (IHR H) as [v H0]; destruct H0 as [r H0]. exists v; exists r; auto.
-destruct (orb_prop _ _ H). Focus 2. destruct (IHR H0) as [v' H1].
+destruct (orb_prop _ _ H).
+  rewrite beq_symb_ok in H0; rewrite <- H0. exists t; exists a2. left; refl.
+destruct (IHR H0) as [v' H1].
 destruct H1 as [r H1]. exists v'; exists r. auto.
-rewrite beq_symb_ok in H0; rewrite <- H0. exists t; exists a2. left; refl.
 Qed.
 
 Fixpoint list_defined (l : rules) : list Sig :=

--- a/Term/WithArity/ADepRel.v
+++ b/Term/WithArity/ADepRel.v
@@ -121,7 +121,7 @@ by a function testing whether a symbol occurs in a term
     intro Rc; elim Rc; simpl; intros; try tauto.
     case_eq (root_eq f (lhs a) && Inb (@eq_rule_dec _) a R); intro H1;
       rewrite H1 in H0.
-    Focus 2. apply (H R f g H0).
+      2: apply (H R f g H0).
     rewrite andb_true_iff in H1; destruct H1. destruct (in_app_or H0).
     exists a; split; auto. apply (Inb_true (@eq_rule_dec _) _ _ H2).
     apply (H R f g H3).
@@ -147,7 +147,7 @@ by a function testing whether a symbol occurs in a term
     simpl; intros. apply incl_nil.
     intros. simpl.
     case_eq (root_eq f (lhs a) && Inb (@eq_rule_dec _) a R); intro H0.
-    Focus 2. apply IHRc1. apply incl_cons_l_incl with (x := a); auto.
+      2: apply IHRc1; apply incl_cons_l_incl with (x := a); auto.
     apply incl_app. intros g Hg. rewrite andb_true_iff in H0. destruct H0.
     apply symb_ord_img_recP2 with (a := a); auto.
     apply (Inb_true (@eq_rule_dec _) _ _ H1). apply (incl_cons_l_in H).

--- a/Term/WithArity/AShift.v
+++ b/Term/WithArity/AShift.v
@@ -31,7 +31,7 @@ Section S.
 
     Definition shift_var x := x+p.
 
-    From CoLoR Require Import ASubstitution.
+    Import ASubstitution.
 
     Definition shift_sub x := @Var Sig (x+p).
     Definition shift := sub shift_sub.

--- a/Term/WithArity/ATrsNorm.v
+++ b/Term/WithArity/ATrsNorm.v
@@ -69,7 +69,7 @@ Section S.
 
     Variable symb_cmp : Sig -> Sig -> comparison.
 
-    From Coq Require Import Compare_dec.
+    Import Compare_dec.
 
     Fixpoint cmp (t u : term) : comparison :=
       match t, u with

--- a/Util/Integer/BigZUtil.v
+++ b/Util/Integer/BigZUtil.v
@@ -12,10 +12,6 @@ Set Implicit Arguments.
 From CoLoR Require Import LogicUtil BigNUtil NatUtil.
 From Bignums Require Export BigZ.
 
-Lemma eq_bigZ_dec : forall x y : bigZ, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_bigN_dec. Defined.
-
 From Coq Require Import Zcompare.
 
 Open Scope bigZ_scope.

--- a/Util/Nat/BigNUtil.v
+++ b/Util/Nat/BigNUtil.v
@@ -14,60 +14,7 @@ From CoLoR Require Import LogicUtil.
 (***********************************************************************)
 (** decidability of equality *)
 
-From Coq Require Import Int31.
-
-Lemma eq_digits_dec : forall x y : digits, {x=y}+{~x=y}.
-
-Proof. decide equality. Defined.
-
-Lemma eq_int31_dec : forall x y : int31, {x=y}+{~x=y}.
-
-Proof. (*SLOW*)decide equality; apply eq_digits_dec. Defined.
-
-Ltac bad_case := right; intro; inversion H; contr.
-Ltac case_tac x y := case (eq_digits_dec x y); [idtac|bad_case].
-
 From Bignums Require Import BigN. Import BigN.
-
-Definition w0 := Cyclic31.Int31Cyclic.t.
-
-Lemma eq_BigN_w0_dec : forall x y : w0, {x=y}+{~x=y}.
-
-Proof.
-  destruct x. destruct y.
-  case_tac d d30. case_tac d0 d31. case_tac d1 d32. case_tac d2 d33.
-  case_tac d3 d34. case_tac d4 d35. case_tac d5 d36. case_tac d6 d37.
-  case_tac d7 d38. case_tac d8 d39. case_tac d9 d40. case_tac d10 d41.
-  case_tac d11 d42. case_tac d12 d43. case_tac d13 d44. case_tac d14 d45.
-  case_tac d15 d46. case_tac d16 d47. case_tac d17 d48. case_tac d18 d49.
-  case_tac d19 d50. case_tac d20 d51. case_tac d21 d52. case_tac d22 d53.
-  case_tac d23 d54. case_tac d24 d55. case_tac d25 d56. case_tac d26 d57.
-  case_tac d27 d58. case_tac d28 d59. case_tac d29 d60. intros. subst. auto.
-(*SLOW*)Defined.
-
-Lemma eq_BigN_w1_dec : forall x y : w1, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w0_dec. Defined.
-
-Lemma eq_BigN_w2_dec : forall x y : w2, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w1_dec. Defined.
-
-Lemma eq_BigN_w3_dec : forall x y : w3, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w2_dec. Defined.
-
-Lemma eq_BigN_w4_dec : forall x y : w4, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w3_dec. Defined.
-
-Lemma eq_BigN_w5_dec : forall x y : w5, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w4_dec. Defined.
-
-Lemma eq_BigN_w6_dec : forall x y : w6, {x=y}+{~x=y}.
-
-Proof. decide equality; apply eq_BigN_w5_dec. Defined.
 
 From Coq Require Import DoubleType.
 
@@ -92,22 +39,6 @@ Section word.
 End word.
 
 From CoLoR Require Import EqUtil.
-
-Lemma eq_bigN_dec : forall x y : bigN, {x=y}+{~x=y}.
-
-Proof.
-  induction x; destruct y; try (right; discr).
-  case (eq_BigN_w0_dec t0 t1); intro. subst. auto. bad_case.
-  case (eq_BigN_w1_dec w w7); intro. subst. auto. bad_case.
-  case (eq_BigN_w2_dec w w7); intro. subst. auto. bad_case.
-  case (eq_BigN_w3_dec w w7); intro. subst. auto. bad_case.
-  case (eq_BigN_w4_dec w w7); intro. subst. auto. bad_case.
-  case (eq_BigN_w5_dec w w7); intro. subst. auto. bad_case.
-  case (eq_BigN_w6_dec w w7); intro. subst. auto. bad_case.
-  case (eq_nat_dec n n0); [idtac|bad_case]. intro. subst n0.
-  case (eq_word_dec eq_BigN_w6_dec _ w w7); intro. subst. auto.
-  right. intro. inversion H. ded (inj_existT eq_nat_dec H1). contr.
-Defined.
 
 (***********************************************************************)
 (** properties of ?= on BigN *)


### PR DESCRIPTION
Removes a few causes for warning (Focus, Require within sections, undeclared scopes).

Removes dead code about decidability of Leibniz equality of bignums.