### PR TITLE
Remove duplicate abstraction

### DIFF
--- a/Util/FMap/FMapUtil.v
+++ b/Util/FMap/FMapUtil.v
@@ -46,7 +46,7 @@ Module Make (Export XMap : FMapInterface.S).
 
     Proof. fo. Qed.
 
-    Global Instance Equiv_m A : Proper (same ==> same) (@Equiv A).
+    Global Instance Equiv_m : Proper (same ==> same) (@Equiv A).
 
     Proof. fo. Qed.
 


### PR DESCRIPTION
`A` is already abstracted over as a section parameter. Since `Equiv_m` is not used in this file, the extra specificity within `Section S` is not an issue.
Adds compatibility with coq/coq#8820.