### PR TITLE
Don’t rely on a random hint

### DIFF
--- a/DP/ASCCUnion.v
+++ b/DP/ASCCUnion.v
@@ -72,7 +72,7 @@ Section S.
     cut (exists j, j=i /\ In j (nats_decr_lt dim)).
     intros; destruct H1. destruct H1. 
     rewrite <- In_nats_decr_lt in H2. subst i; auto.
-    eapply permutation_in. auto using gen_st.
+    eapply permutation_in. constructor; congruence.
     apply permutation_sym. eauto. auto.
   Qed.
 


### PR DESCRIPTION
Using `info_auto` suggests this proof script.

The current proof relies on hints that are internal to the `FSets` library and accidentally leak there.
