### PR TITLE
Use hints from the “ordered_type” database

### DIFF
--- a/Util/FGraph/FGraph.v
+++ b/Util/FGraph/FGraph.v
@@ -609,7 +609,7 @@ successors of g' *)
     unfold add_edge, Relation_Operators.union, id. split_all.
     destruct H as [sa [a1 a2]]. rewrite add_o in a1. destruct (eq_dec x a).
     inversion a1. subst sa. rewrite add_iff in a2. rewrite In_succs_rel in a2.
-    rewrite e in a2. split_all.
+    rewrite e in a2. split_all. auto with ordered_type.
     left. exists sa. tauto.
     destruct H as [sa [a1 a2]]. unfold rel. rewrite add_o.
     destruct (eq_dec x a).
@@ -617,7 +617,7 @@ successors of g' *)
     rewrite e, In_succs_rel. exists sa. auto.
     exists sa. auto.
     unfold rel. rewrite add_o. destruct (eq_dec x a).
-    exists (XSet.add y (succs x g)). split_all. rewrite add_iff. auto.
+    exists (XSet.add y (succs x g)). split_all. rewrite add_iff. auto with ordered_type.
     absurd (eq x a); hyp.
   Qed.
 

--- a/Util/FGraph/TransClos.v
+++ b/Util/FGraph/TransClos.v
@@ -273,7 +273,7 @@ the transitive closure of [id x y U g] *)
     case_eq (XSet.mem y (succs x g)); intros. refl.
     intro z. rewrite In_succs_rel, rel_map_fold_add_pred_ext,
     rel_set_fold_add_edge_ext. unfold pred, succ. rewrite union_iff.
-    rewrite !add_iff, !In_succs_rel. split_all.
+    rewrite !add_iff, !In_succs_rel. split_all; auto with ordered_type.
   Qed.
 
   Lemma preds_trans_add_edge_id : forall x y g,
@@ -291,7 +291,7 @@ the transitive closure of [id x y U g] *)
     (* x in ysy *)
     rewrite add_iff, In_preds_rel. unfold ysy in H0.
     rewrite XSetFacts.add_b, orb_eq, eqb_ok, mem_succs_rel in H0.
-    unfold ysy, pred, succ. rewrite add_iff, In_succs_rel. split_all.
+    unfold ysy, pred, succ. rewrite add_iff, In_succs_rel. split_all; auto with ordered_type.
     (* x not in ysy *)
     unfold ysy, pred, succ. rewrite add_iff, In_succs_rel, In_preds_rel.
     rewrite false_not_true in H, H0. unfold ysy in H0.

--- a/Util/FMap/FMapUtil.v
+++ b/Util/FMap/FMapUtil.v
@@ -352,9 +352,9 @@ Module Make (Export XMap : FMapInterface.S).
 
     Proof.
       intros n k x m' hk [h1 h2].
-      assert (In k (add k x n)). rewrite add_in_iff. auto.
+      assert (In k (add k x n)). rewrite add_in_iff. auto with ordered_type.
       rewrite h1 in H. destruct H as [x']. exists x'. split.
-      apply h2 with k. rewrite add_mapsto_iff. auto. hyp.
+      apply h2 with k. rewrite add_mapsto_iff. auto with ordered_type. hyp.
       intro l. rewrite add_o. rewrite remove_o. destruct (eq_dec k l).
       rewrite <- e. rewrite <- find_mapsto_iff. hyp. refl.
     Qed.
@@ -397,7 +397,7 @@ and satisfies some commutation property. *)
         rewrite fold_add; auto. destruct (Equiv_add nxm xemm') as [x' [h1 h2]].
         assert (n: ~In k (remove k m')). apply remove_1. refl.
         rewrite fold_Add with (m2:=m'); auto. 2: apply n. 2: apply h2.
-        apply f_m; auto. apply hm; auto.
+        apply f_m; auto with ordered_type. apply hm; auto.
         eapply Equiv_add_remove. hyp. apply xemm'.
       Qed.
 
@@ -686,7 +686,7 @@ and satisfies some commutation property. *)
         (* add *)
         intros x T E hx h F e xs xs' xsxs'. rewrite restrict_dom_add. 2: hyp.
         unfold restrict_dom at -1. rewrite <- (fold_Equal _ _ _ e).
-        rewrite fold_add; auto. apply restrict_fun_e; auto. apply h; auto. refl.
+        rewrite fold_add; auto. apply restrict_fun_e; auto with ordered_type. apply h; auto. refl.
         apply restrict_fun_e. refl. apply restrict_fun_transp.
       Qed.
  
@@ -743,7 +743,7 @@ and satisfies some commutation property. *)
       Lemma mapsto_restrict_dom_singleton : forall x T E,
           MapsTo x T E -> MapsTo x T (restrict_dom E (singleton x)).
 
-      Proof. intros x T E h. rewrite mapsto_restrict_dom. set_iff. auto. Qed.
+      Proof. intros x T E h. rewrite mapsto_restrict_dom. set_iff. auto with ordered_type. Qed.
 
 (****************************************************************************)
 (** ** Domain of a typing environment. *)

--- a/Util/FSet/FSetUtil.v
+++ b/Util/FSet/FSetUtil.v
@@ -12,6 +12,8 @@ Set Implicit Arguments.
 From Coq Require Import FSets.
 From CoLoR Require Import LogicUtil RelUtil BoolUtil.
 
+Create HintDb ordered_type.
+
 Module Make (Export XSet : FSetInterface.S).
 
   Module Export XSetEqProps := EqProperties XSet.
@@ -70,7 +72,7 @@ Module Make (Export XSet : FSetInterface.S).
 
   Lemma eqb_refl x : eqb x x = true.
 
-  Proof. eq_dec x x. refl. absurd (x=x); auto. Qed.
+  Proof. eq_dec x x. refl. absurd (x=x); auto with ordered_type. Qed.
 
   Hint Rewrite eqb_refl : mem.
 
@@ -480,9 +482,9 @@ Module Make (Export XSet : FSetInterface.S).
 
   Lemma notin_replace x y xs : E.eq y x \/ ~In x (replace x y xs).
 
-  Proof.
-    eq_dec y x. auto. unfold replace. case_eq (mem x xs); intro hx; set_iff.
-    right. split_all. right. rewrite not_mem_iff. hyp.
+  Proof with auto with ordered_type.
+    eq_dec y x... unfold replace. case_eq (mem x xs); intro hx; set_iff.
+    right. split_all... right. rewrite not_mem_iff. hyp.
   Qed.
 
   Lemma replace_idem x xs : replace x x xs [=] xs.


### PR DESCRIPTION
This makes explicit the calls to `auto` that rely on hints that will move to the `ordered_type` database (in Coq standard library).

See https://github.com/coq/coq/pull/9772 for details.