### PR TITLE
Improve handling of `Vbuild` obligations

### DIFF
--- a/Util/Vector/VecUtil.v
+++ b/Util/Vector/VecUtil.v
@@ -1749,11 +1749,9 @@ Section Vbuild.
           Vcons (gen 0 _) (@Vbuild_spec p gen')
     end.
 
-  Solve Obligations with try omega.
-  (*COQ: why these obligations are not solved?*)
-  Next Obligation. omega. Qed.
+  Solve Obligations with program_simplify; try omega.
   Next Obligation.
-    assert (h : Vbuild_spec_obligation_5 (eq_refl (S p)) = eq_refl (S p)).
+    assert (h : Vbuild_spec_obligation_5 gen (eq_refl (S p)) = eq_refl (S p)).
     apply eq_unique.
     rewrite h. simpl. destruct i.
     f_equal. apply lt_unique.

--- a/Util/Vector/VecUtil.v
+++ b/Util/Vector/VecUtil.v
@@ -1749,6 +1749,8 @@ Section Vbuild.
           Vcons (gen 0 _) (@Vbuild_spec p gen')
     end.
 
+  Local Unset Transparent Obligations.
+
   Solve Obligations with try (idtac + program_simplify; omega).
   Next Obligation.
     assert (h : Vbuild_spec_obligation_5 (eq_refl (S p)) = eq_refl (S p)).

--- a/Util/Vector/VecUtil.v
+++ b/Util/Vector/VecUtil.v
@@ -1749,9 +1749,9 @@ Section Vbuild.
           Vcons (gen 0 _) (@Vbuild_spec p gen')
     end.
 
-  Solve Obligations with program_simplify; try omega.
+  Solve Obligations with try (idtac + program_simplify; omega).
   Next Obligation.
-    assert (h : Vbuild_spec_obligation_5 gen (eq_refl (S p)) = eq_refl (S p)).
+    assert (h : Vbuild_spec_obligation_5 (eq_refl (S p)) = eq_refl (S p)).
     apply eq_unique.
     rewrite h. simpl. destruct i.
     f_equal. apply lt_unique.


### PR DESCRIPTION
Fix `Solve Obligation`, and make all obligations involving `Omega` opaque. I just spotted these possible improvements while looking at #22 and noticing a TODO; I'm a fan of `Global Unset Transparent Obligations.` (see [stdpp](https://gitlab.mpi-sws.org/iris/stdpp/blob/215f99da2d8ee67dfda59ac21bcd7ea1209fdb02/theories/base.v#L20-29) for a rationale), but you know your code best.