### PR TITLE
overlay for coq/coq#12162 after merge of coq/coq#12008

### DIFF
--- a/Coccinelle/term_orderings/rpo.v
+++ b/Coccinelle/term_orderings/rpo.v
@@ -13,6 +13,7 @@
 quasi-ordering for the precedence instead of an ordering. *)
 
 From Coq Require Import Bool.
+From Coq Require Import Peano.
 From Coq Require Import List.
 From CoLoR Require Import closure.
 From CoLoR Require Import more_list.


### PR DESCRIPTION
Because of coq/coq#12008 we have to take `lt` into account as well in coq/coq#12162.