### PR TITLE
Be robust to a change in the default argument naming algorithm.

### DIFF
--- a/Term/Lambda/LAlpha.v
+++ b/Term/Lambda/LAlpha.v
@@ -1260,14 +1260,14 @@ while [subs (comp s1 s2) u = Lam y (Var x)] since [comp s1 s2 x = s2 y
     rewrite Vforall2_cons_eq. intuition.
   Qed.
 
-  Arguments apps_aeq_r [n vs v t0] _.
+  Arguments apps_aeq_r [n vs v t0] _ : rename.
 
   Lemma apps_aeq_l : forall n (vs : Tes n) v t, apps v vs ~~ t ->
     exists u us, t = apps u us /\ u ~~ v /\ vaeq us vs.
 
   Proof. intros n vs v t e. apply apps_aeq_r. hyp. Qed.
 
-  Arguments apps_aeq_l [n vs v t0] _.
+  Arguments apps_aeq_l [n vs v t0] _ : rename.
 
 (****************************************************************************)
 (** Extended inversion tactic for alpha-equivalence. *)

--- a/Term/Lambda/LBeta.v
+++ b/Term/Lambda/LBeta.v
@@ -202,7 +202,7 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     exists u. exists (Vcons h vs). intuition. do 2 apply right_sym. hyp.
   Qed.
 
-  Arguments beta_apps_no_lam [n us u t0] _ _.
+  Arguments beta_apps_no_lam [n us u t0] _ _ : rename.
 
   Lemma beta_aeq_apps_no_lam : forall n (us : Tes n) u t,
     not_lam u -> apps u us =>b t ->
@@ -218,7 +218,7 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     exists (Vcons v vs). split. fo. exists (Vcons w ws). intuition. fo.
   Qed.
 
-  Arguments beta_aeq_apps_no_lam [n us u t0] _ _.
+  Arguments beta_aeq_apps_no_lam [n us u t0] _ _ : rename.
 
   Lemma beta_aeq_apps_fun f n (us : Tes n) t : apps (Fun f) us =>b t ->
     exists vs, t = apps (Fun f) vs /\ clos_vaeq beta us vs.
@@ -230,7 +230,7 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     inv_beta_aeq h1. simpl_aeq. subst. auto.
   Qed.
 
-  Arguments beta_aeq_apps_fun [f n us t0] _.
+  Arguments beta_aeq_apps_fun [f n us t0] _ : rename.
 
 (****************************************************************************)
 (** [apps (Fun f) us] is strongly normalizing wrt beta-reduction if

--- a/Term/Lambda/LCompRewrite.v
+++ b/Term/Lambda/LCompRewrite.v
@@ -207,7 +207,7 @@ Module Make (Export RS : RS_Struct).
     destruct us; simpl in H. discr. rewrite apps_app in H. discr.
   Qed.
 
-  Arguments rewrite_apps_fun [f n us t0] _.
+  Arguments rewrite_apps_fun [f n us t0] _ : rename.
 
   Lemma rewrite_aeq_apps_fun : forall f n (us : Tes n) t,
     apps (Fun f) us =>S t ->
@@ -230,7 +230,7 @@ Module Make (Export RS : RS_Struct).
     rewrite Vcast_refl. intuition. rewrite i0, i2. refl.
   Qed.
 
-  Arguments rewrite_aeq_apps_fun [f n us t0] _.
+  Arguments rewrite_aeq_apps_fun [f n us t0] _ : rename.
 
 End Make.
 
@@ -408,7 +408,7 @@ Module CP_beta_eta_rewrite (Import RS : RS_Struct) <: LComp.CP_Struct.
     right. ex p ls r s q vs h0. split_all.
   Qed.
 
-  Arguments beta_eta_rewrite_aeq_apps_fun [f n us t0] _.
+  Arguments beta_eta_rewrite_aeq_apps_fun [f n us t0] _ : rename.
 
   (** Some notations. *)
   (*COQ: can we avoid to repeat these notations already declared in CP_Struct?*)

--- a/Term/Lambda/LEta.v
+++ b/Term/Lambda/LEta.v
@@ -204,7 +204,7 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     ex u (Vcons h vs). split_all. do 2 apply right_sym. hyp.
   Qed.
 
-  Arguments eta_apps [n us u t0] _.
+  Arguments eta_apps [n us u t0] _ : rename.
 
   Lemma eta_aeq_apps : forall n (us : Tes n) u t, apps u us =>e t ->
     exists v vs, t = apps v vs /\ Vcons u us ==>e Vcons v vs.
@@ -218,7 +218,7 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     ex (Vcons v vs). split. fo. ex (Vcons w ws). split_all. fo.
   Qed.
 
-  Arguments eta_aeq_apps [n us u t0] _ .
+  Arguments eta_aeq_apps [n us u t0] _ : rename.
 
   Lemma eta_aeq_apps_fun f n (us : Tes n) t : apps (Fun f) us =>e t ->
     exists vs, t = apps (Fun f) vs /\ us ==>e vs.
@@ -230,6 +230,6 @@ then [t] is of the form [apps v vs] with [Vcons u us ==>b Vcons v vs]. *)
     inv_eta_aeq h1. simpl_aeq. subst. auto.
   Qed.
 
-  Arguments eta_aeq_apps_fun [f n us t0] _.
+  Arguments eta_aeq_apps_fun [f n us t0] _ : rename.
 
 End Make.

--- a/Term/WithArity/ACalls.v
+++ b/Term/WithArity/ACalls.v
@@ -163,7 +163,7 @@ unfold Q. simpl. intro. contr.
 unfold Q. simpl. intros. ded (in_app_or H1). intuition.
 Qed.
 
-Arguments in_calls [x t0] _.
+Arguments in_calls [x t0] _ : rename.
 
 Lemma in_calls_defined : forall t g vs,
   In (Fun g vs) (calls t) -> defined g R = true.
@@ -234,7 +234,7 @@ Qed.
 
 End S.
 
-Arguments in_calls [Sig R x t0] _.
-Arguments in_calls_defined [Sig R t0 g vs] _.
+Arguments in_calls [Sig R x t0] _ : rename.
+Arguments in_calls_defined [Sig R t0 g vs] _ : rename.
 Arguments in_calls_subterm [Sig R u t] _.
 Arguments lhs_fun_defined [Sig f us r R] _.

--- a/Term/WithArity/ASubstitution.v
+++ b/Term/WithArity/ASubstitution.v
@@ -737,7 +737,7 @@ Arguments fun_eq_sub [Sig f ts s u] _.
 Arguments sub_restrict_incl [Sig] _ [l r] _.
 Arguments fresh_vars [Sig] _.
 Arguments fresh [Sig] _ _.
-Arguments subterm_eq_sub_elim [Sig u t0 s] _.
+Arguments subterm_eq_sub_elim [Sig u t0 s] _ : rename.
 
 (***********************************************************************)
 (** tactics *)

--- a/Term/WithArity/ATerm.v
+++ b/Term/WithArity/ATerm.v
@@ -680,9 +680,9 @@ Arguments maxvar_var [Sig k x] _.
 Arguments maxvar_le_fun [Sig m f ts] _.
 Arguments maxvar_le_arg [Sig f ts m t] _ _.
 Arguments in_vars_vec_elim [Sig x n ts] _.
-Arguments vars_vec_in [Sig x t0 n ts] _ _.
+Arguments vars_vec_in [Sig x t0 n ts] _ _ : rename.
 Arguments in_symbs_vec_elim [Sig x n ts] _.
-Arguments symbs_vec_in [Sig x t0 n ts] _ _.
+Arguments symbs_vec_in [Sig x t0 n ts] _ _ : rename.
 Arguments vars_max [Sig x t] _.
 Arguments Vin_nb_symb_occs_terms_ge [Sig n ts t] _.
 Arguments Vin_size_terms_ge [Sig n ts t] _.

--- a/Util/FMap/FMapUtil.v
+++ b/Util/FMap/FMapUtil.v
@@ -611,8 +611,8 @@ and satisfies some commutation property. *)
 
   End S.
 
-  Arguments Equiv_find_Some [A eq0 m m'] _ [k x] _.
-  Arguments Equiv_find_Some' [A eq0 m m'] _ [k x] _.
+  Arguments Equiv_find_Some [A eq0 m m'] _ [k x] _ : rename.
+  Arguments Equiv_find_Some' [A eq0 m m'] _ [k x] _ : rename.
   Arguments le {A} _ _.
 
 (****************************************************************************)

--- a/Util/Vector/VecArith.v
+++ b/Util/Vector/VecArith.v
@@ -262,7 +262,7 @@ Module OrdVectorArith (OSRT : OrdSemiRingType).
 
   Proof. apply Vforall2_aux_Proper. class. Qed.
 
-  Arguments vec_ge_mor [n x y] _ [x0 y0] _.
+  Arguments vec_ge_mor [n x y] _ [x0 y0] _ : rename.
 
   Lemma vec_plus_ge_compat : forall n (vl vl' vr vr' : vec n), 
     vl >=v vl' -> vr >=v vr' -> vl [+] vr >=v vl' [+] vr'.


### PR DESCRIPTION
Overlay for coq/coq#12756.

This overlay preserves all the old names; the new default names
are just `t` instead of `t0`.

For some context, the old algorithm saw the unqualified name `t`
referring to (apparently) `L.V.XSet.t` and refreshed the argument
names to not conflict, which I don't believe is necessary.

The only exception to this is in `VecArith.v` on `vec_ge_mor`,
where the two sets of arguments `x y` coming from unfolding the
`Proper (... ==> ... ==> ...)` type used to be refreshed into
`x y _ x0 y0 _`, and are now by default the overlapping `x y _ x y _`.
Thus if you want to refer to the second set of arguments in an explicit
application like `vec_ge_mor (x0 := ...)`, they have to be explicitly
renamed as is done here.