### PR TITLE
Adapt to coq/coq#13837 (apply with does not rename arguments)

### DIFF
--- a/DP/ADP.v
+++ b/DP/ADP.v
@@ -204,7 +204,7 @@ Lemma chain_min_fun : forall f, defined f R = true
 Proof.
 cut (forall t, SN chain_min t -> forall f, defined f R = true
   -> forall ts, t = Fun f ts -> Vforall SNR ts -> SNR t).
-intros. apply H with (t0 := Fun f ts) (f := f) (ts := ts); (hyp || refl).
+intros. apply H with (f := f) (ts := ts); (hyp || refl).
 (* induction on t with chain_min as well-founded ordering *)
 intros t H. elim H. clear t H. intros t H IH f H0 ts H1 Hsnts.
 assert (SN (Vrel1 (red R)) ts). apply Vforall_SN_rel1. hyp.

--- a/Term/Lambda/LSimple.v
+++ b/Term/Lambda/LSimple.v
@@ -570,7 +570,7 @@ are finite maps from variables to types. *)
     rewrite mapsto_restrict_dom. intros [i1 i2].
     exfalso. eapply var_notin_fv_subs. apply h3. apply n. apply i2.
     (* find x' F' = None *)
-    intro i. eapply tr_le with (x:=add x' X0 F') (x0:=s y) (x1:=T); try refl.
+    intro i. eapply tr_le with (x:=add x' X0 F'); try refl.
     unfold F'. rewrite restrict_dom_le. refl. rewrite <- le_add; hyp.
   Qed. 
 


### PR DESCRIPTION
Here we can get away with just not specifying the renamed arguments,
which is nice for backwards compat.