### PR TITLE
Adapt to coq/coq#15071 (namegen doesn't avoid names from imported modules)

### DIFF
--- a/Coccinelle/list_extensions/list_sort.v
+++ b/Coccinelle/list_extensions/list_sort.v
@@ -260,7 +260,7 @@ dummy a a' a_eq_a'; subst; trivial.
 generalize (o_bool_ok a' e); rewrite a'_ge_e; intro a'_ge_e'.
 destruct (o_total e a'); intros.
 assumption.
-absurd (o a' e); assumption.
+absurd (DOS.o a' e); assumption.
 Qed.
 
 Theorem quick_sorted : forall l, is_sorted (quicksort l).

--- a/HORPO/Computability.v
+++ b/HORPO/Computability.v
@@ -60,13 +60,13 @@ Section Computability_def.
     Computable M.
 
   Proof.
-    intro M; term_type_inv M; intros.
+    intros [E Pt [?|A1 A2] Typ];try_solve; intros.
     hnf; intros; split; trivial.
     split; trivial.
     intros; unfold Computable in H1.
     rewrite <- typeL.
     apply H1 with Papp; trivial.
-    rewrite (@app_typeR P A0_1 A0_2 Papp); trivial.
+    rewrite (@app_typeR P A1 A2 Papp); trivial.
     rewrite (terms_conv_eq_type PL); trivial.
   Qed.
 
@@ -171,6 +171,8 @@ Section Computability_theory.
   Proof.
     intros.
     term_inv M'; term_inv N'.
+    (* compat: variables are A0, A1 before coq 8.15 but A, A0 after *)
+    try (rename A0 into A1; rename A into A0).
     assert (EE0: E = E0).
     replace E with (env M).
     replace E0 with (env N).

--- a/HORPO/Horpo.v
+++ b/HORPO/Horpo.v
@@ -264,7 +264,9 @@ Module Horpo (S : TermsSig.Signature)
     intros.
     inversion H0.
     term_inv M; term_inv N.
-    destruct (pair_mOrd horpo_eq_compat' H1) as 
+    (* compat: variables are A0, A1 before coq 8.15 but A, A0 after *)
+    try (rename A0 into A1; rename A into A0).
+    destruct (pair_mOrd horpo_eq_compat' H1) as
       [o1 | [o2 | [o3 | o4]]].
      (* Ml:Nl Ml:Nr *)
     absurd (A1 = A1 --> B0).

--- a/HORPO/HorpoWf.v
+++ b/HORPO/HorpoWf.v
@@ -316,7 +316,7 @@ Module HorpoWf (S : TermsSig.Signature)
     apply subterm_wf.
     clear M; intros M IH G MG Mnorm Gcomp Gnorm.
     destruct M as [E Pt TM TypM]; simpl in * .
-    destruct Pt.
+    destruct Pt as [?|?|A0 ?|??].
      (* variable *)
     assert (Mvar: isVar (buildT TypM)).
     dependent inversion TypM; simpl; trivial.

--- a/MatrixInt/AArcticInt.v
+++ b/MatrixInt/AArcticInt.v
@@ -95,8 +95,8 @@ Module ArcticInt (Import AI : TArcticInt).
 
     Definition Sig := Sig.
 
-    Lemma mat_times_vec_at0_positive : forall n (m : matrix n n) 
-      (v : vector A n) (dim_pos : n > 0),
+    Lemma mat_times_vec_at0_positive n (m : matrix n n)
+      (v : vector A n) (dim_pos : n > 0) :
       get_elem m dim_pos dim_pos <> MinusInf ->   
       Vnth v dim_pos <> MinusInf ->
       Vnth (mat_vec_prod m v) dim_pos <> MinusInf.
@@ -110,7 +110,7 @@ Module ArcticInt (Import AI : TArcticInt).
       simpl. rewrite Aplus_comm. apply arctic_plus_notInf_left.
       apply arctic_mult_notInf. 
       rewrite H2 in H. unfold get_elem in H. simpl in H.
-      rewrite Vhead_nth, <- (Vnth_eq (Vhead m) dim_pos0 (lt_O_Sn n)); trivial.
+      rewrite Vhead_nth, <- (Vnth_eq (Vhead m) dim_pos (lt_O_Sn n)); trivial.
       rewrite H1 in H0. hyp.
     Qed.
 

--- a/MatrixInt/ATropicalInt.v
+++ b/MatrixInt/ATropicalInt.v
@@ -99,8 +99,8 @@ Module TropicalInt (Import AI : TTropicalInt).
 
     Definition Sig := Sig.
 
-    Lemma mat_times_vec_at0_positive : forall n (m : matrix n n) 
-      (v : vector A n) (dim_pos : n > 0),
+    Lemma mat_times_vec_at0_positive n (m : matrix n n)
+      (v : vector A n) (dim_pos : n > 0) :
       get_elem m dim_pos dim_pos <> PlusInf ->   
       Vnth v dim_pos <> PlusInf ->
       Vnth (mat_vec_prod m v) dim_pos <> PlusInf.
@@ -114,7 +114,7 @@ Module TropicalInt (Import AI : TTropicalInt).
       simpl. rewrite Aplus_comm. apply tropical_plus_notInf_left.
       apply tropical_mult_notInf. 
       rewrite H2 in H. unfold get_elem in H. simpl in H.
-      rewrite Vhead_nth, <- (Vnth_eq (Vhead m) dim_pos0 (lt_O_Sn n)); trivial.
+      rewrite Vhead_nth, <- (Vnth_eq (Vhead m) dim_pos (lt_O_Sn n)); trivial.
       rewrite H1 in H0. hyp.
     Qed.
 

--- a/Term/Lambda/LCompSimple.v
+++ b/Term/Lambda/LCompSimple.v
@@ -140,6 +140,7 @@ Module Make (Export ST : ST_Struct)
       simpl. gen (hu _ _ H2 _ hs); intro h1. simpl in h1. apply h1.
       eapply hv. apply H4. hyp.
       (* lam *)
+      try rename X into X0. (* compat: variable is X0 before coq 8.15 but X after *)
       rename X0 into A; rename V0 into V.
       simpl. set (x' := var x v s). set (s' := S.update x (Var x') s).
       gen (cp_int A). intros [A1 A2 A3 A4].
@@ -497,9 +498,10 @@ Module SN_beta_eta (Export ST : ST_Struct).
     (* Since [apps (Fun f) x] is neutral, it suffices to prove that all its
     reducts are computable. *)
     apply b4. apply neutral_apps_fun.
-    intros y r. Arguments R_aeq_apps_fun [f n us t0] _ : rename.
+    intros y r. 
     destruct (R_aeq_apps_fun r) as [vs [h1 h2]]; clear r; subst.
     apply H0. hyp. rewrite <- h2. hyp.
   Qed.
 
+  Arguments R_aeq_apps_fun [f n us t0] _ : rename.
 End SN_beta_eta.

--- a/Term/Lambda/LSimple.v
+++ b/Term/Lambda/LSimple.v
@@ -478,11 +478,13 @@ are finite maps from variables to types. *)
     E |- v ~: V -> forall y, ~XSet.In y (fv v) -> remove y E |- v ~: V.
 
   Proof.
-    induction 1; intro y; simpl; set_iff; intro hy.
+    induction 1 ; intro y; simpl; set_iff; intro hy.
     apply tr_var. apply remove_2; auto.
     apply tr_fun.
     apply tr_app with V. apply IHtr1. tauto. apply IHtr2. tauto.
-    apply tr_lam. eq_dec x y.
+    apply tr_lam.
+    try rename X into X0. (* compat: variable is X0 before coq 8.15 but X after *)
+    eq_dec x y.
     (* x = y *)
     eapply tr_le with (x:=add x X0 E). 2: refl. 2: refl.
     intros z hz. env. do 2 rewrite find_mapsto_iff, add_o. eq_dec x z; auto.
@@ -570,7 +572,7 @@ are finite maps from variables to types. *)
     rewrite mapsto_restrict_dom. intros [i1 i2].
     exfalso. eapply var_notin_fv_subs. apply h3. apply n. apply i2.
     (* find x' F' = None *)
-    intro i. eapply tr_le with (x:=add x' X0 F'); try refl.
+    intro i. eapply tr_le with (x:=add x' _ F'); try refl.
     unfold F'. rewrite restrict_dom_le. refl. rewrite <- le_add; hyp.
   Qed. 
 
@@ -591,6 +593,7 @@ are finite maps from variables to types. *)
     eapply hu. apply H2. hyp. hyp.
     eapply hv. apply H4. hyp. hyp.
     (* lam *)
+    try rename X into X0. (* compat: variable is X0 before coq 8.15 but X after *)
     apply tr_lam. eapply hu with (u':=rename x x1 v) (E:=add x1 X0 E).
     rewrite size_rename. refl. unfold Def.rename. eapply tr_subs.
     eapply tr_restrict. apply H3. 2: rewrite EE'; refl. 2: hyp.

--- a/Term/SimpleType/TermsBeta.v
+++ b/Term/SimpleType/TermsBeta.v
@@ -79,8 +79,8 @@ Module TermsBeta (Sig : TermsSig.Signature).
 
   Proof.
     intros.
-    destruct M.
-    destruct typing0; try contr.
+    destruct M as [??? typingM].
+    destruct typingM; try contr.
     assert (type (appBodyL Mapp) = A --> B).
     trivial.
     rewrite (abs_type (appBodyL Mapp) MLabs H); trivial.
@@ -383,13 +383,12 @@ Module TermsBeta (Sig : TermsSig.Signature).
     correct_subst M (None :: lift_subst G 1).
 
   Proof.
-    intros.
-    destruct H.
-    rewrite H0 in dom_c0.
-    rewrite H0 in ran_c0.
-    rewrite lower_env in dom_c0.
-    rewrite lower_env in ran_c0.
-    clear H0.
+    intros ???? [envNG domNG ranNG] H.
+    rewrite H in domNG.
+    rewrite H in ranNG.
+    rewrite lower_env in domNG.
+    rewrite lower_env in ranNG.
+    clear H.
     constructor.
     apply subst_envs_comp_cons.
     apply lifted_subst_envs_comp; trivial.
@@ -400,9 +399,9 @@ Module TermsBeta (Sig : TermsSig.Signature).
     simpl.
     rewrite subst_dom_lifted.
     apply env_comp_cons; auto.
-    unfold loweredEnv in dom_c0.
-    simpl in dom_c0.
-    rewrite finalSeg_cons in dom_c0; trivial.
+    unfold loweredEnv in domNG.
+    simpl in domNG.
+    rewrite finalSeg_cons in domNG; trivial.
     simpl.
     rewrite subst_ran_cons_none.
     rewrite subst_dom_lifted.
@@ -416,9 +415,9 @@ Module TermsBeta (Sig : TermsSig.Signature).
     destruct o.
     destruct M0; try_solve.
     apply env_comp_cons; auto.
-    unfold loweredEnv in ran_c0.
-    simpl in ran_c0.
-    rewrite finalSeg_cons in ran_c0; trivial.
+    unfold loweredEnv in ranNG.
+    simpl in ranNG.
+    rewrite finalSeg_cons in ranNG; trivial.
   Qed.
 
   Lemma lower_subst_aux : forall M G i, env M |= i :! ->
@@ -479,15 +478,15 @@ Module TermsBeta (Sig : TermsSig.Signature).
     intros.
     apply term_eq; autorewrite with terms; rewrite H; autorewrite with terms.
 
-    destruct M.
+    destruct M as [envM ???].
     autorewrite with terms using simpl.
     unfold loweredEnv; simpl.
     destruct (subst_empty_dec G).
-    destruct env0; simpl.
+    destruct envM; simpl.
     autorewrite with terms; trivial.
     autorewrite with terms datatypes; trivial.
     destruct o; autorewrite with datatypes; trivial.
-    destruct env0; simpl.
+    destruct envM; simpl.
     autorewrite with datatypes terms.
     destruct (subst_ran G); trivial.
     destruct o; autorewrite with datatypes terms using simpl; trivial.

--- a/Term/SimpleType/TermsBuilding.v
+++ b/Term/SimpleType/TermsBuilding.v
@@ -29,11 +29,11 @@ Module TermsBuilding (Sig : TermsSig.Signature).
 
   Proof.
     intro t; inversion t as [L R eq_env typ_arr typ_ok].
-    destruct L; destruct R; simpl in *.
-    rewrite eq_env in typing0.
-    destruct type0; try contr; simpl in *.
-    rewrite typ_ok in typing0.
-    exact (buildT (TApp typing0 typing1)).
+    destruct L as [?? typeL typingL]; destruct R as [??? typingR]; simpl in *.
+    rewrite eq_env in typingL.
+    destruct typeL; try contr; simpl in *.
+    rewrite typ_ok in typingL.
+    exact (buildT (TApp typingL typingR)).
   Defined.
 
   Lemma buildApp_isApp : forall a, isApp (buildApp a).
@@ -84,16 +84,16 @@ Module TermsBuilding (Sig : TermsSig.Signature).
 
   Proof.
     intro t; inversion t as [aBody aType envCond].
-    destruct aBody; simpl in *; destruct env0.
+    destruct aBody as [env ?? typing]; simpl in *; destruct env.
     try_solve.
     destruct o.
-    exact (buildT (TAbs typing0)).
+    exact (buildT (TAbs typing)).
     try_solve.
   Defined.
 
   Lemma buildAbs_isAbs: forall a, isAbs (buildAbs a).
   Proof.
-    destruct a; destruct absB0; destruct env0.
+    destruct a as [[env ???] ??]; destruct env.
     try_solve.
     destruct o; try_solve.
   Qed.
@@ -101,7 +101,7 @@ Module TermsBuilding (Sig : TermsSig.Signature).
   Lemma buildAbs_absBody : forall a, absBody (buildAbs_isAbs a) = a.(absB).
 
   Proof.
-    destruct a; destruct absB0; destruct env0.
+    destruct a as [[env ???] ??]; destruct env.
     try_solve.
     destruct o; try_solve.
   Qed.
@@ -109,7 +109,7 @@ Module TermsBuilding (Sig : TermsSig.Signature).
   Lemma buildAbs_absType : forall a, absType (buildAbs_isAbs a) = a.(absT).
 
   Proof.
-    destruct a; destruct absB0; destruct env0.
+    destruct a as [[env ???] ??]; destruct env.
     try_solve.
     destruct o; try_solve.
     unfold VarD in * .
@@ -119,7 +119,7 @@ Module TermsBuilding (Sig : TermsSig.Signature).
   Lemma buildAbs_env : forall a, env (buildAbs a) = tail (env a.(absB)).
 
   Proof.
-    destruct a; destruct absB0; destruct env0.
+    destruct a as [[env ???] ??]; destruct env.
     try_solve.
     destruct o; try_solve.
   Qed.

--- a/Term/SimpleType/TermsConv.v
+++ b/Term/SimpleType/TermsConv.v
@@ -622,13 +622,13 @@ Module TermsConv (Sig : TermsSig.Signature).
     constructor 3.
     replace (@compEnvSubst E (env N) MN) with 
       (@compEnvSubst (env (buildT (TAbs M))) (env N) MN); trivial.
-    destruct N; destruct typing0; inversion MN_term.
+    destruct N as [??? typingN]; destruct typingN; inversion MN_term.
     assert (EE0: decl A E [<->] decl A0 E0).
     unfold decl; apply env_comp_cons; trivial.
     left; try_solve.
-    rewrite (envSubst_eq_abs (buildT (TAbs M)) (buildT (TAbs typing0)) 
+    rewrite (envSubst_eq_abs (buildT (TAbs M)) (buildT (TAbs typingN))
       I I MN EE0).
-    set (w := IHM (buildT typing0) EE0); simpl in w.
+    set (w := IHM (buildT typingN) EE0); simpl in w.
     rewrite <- H1 in w.
     apply w; trivial.
     constructor 4; term_inv N; inversion MN_term.

--- a/Term/SimpleType/TermsSubst.v
+++ b/Term/SimpleType/TermsSubst.v
@@ -1061,8 +1061,8 @@ Module TermsSubst (Sig : TermsSig.Signature).
   Definition idSubst : forall M : Term, Subst.
 
   Proof.
-    intros M; destruct M.
-    destruct (isVarDecl_dec env0 0) as [[A EA] | EE].
+    intros M; destruct M as [envM ???].
+    destruct (isVarDecl_dec envM 0) as [[A EA] | EE].
     set (var := TVar EA).
     exact ({x/buildT var}).
     assert (var: decl (#baseTypesNotEmpty) EmptyEnv |= 0 := #baseTypesNotEmpty).
@@ -1074,25 +1074,25 @@ Module TermsSubst (Sig : TermsSig.Signature).
     idSubst M = {x/buildT (TVar M0)}.
 
   Proof.
-    destruct M; simpl.
-    destruct (isVarDecl_dec env0 0) as [[B EB] | En].
+    destruct M as [envM ???]; simpl.
+    destruct (isVarDecl_dec envM 0) as [[B EB] | En].
     replace (buildT (TVar EB)) with (buildT (TVar M0)); trivial.
     apply term_eq; trivial.
-    exfalso; apply varD_UD_absurd with env0 0 A; trivial.
+    exfalso; apply varD_UD_absurd with envM 0 A; trivial.
   Qed.
 
   Lemma idSubst_correct M : correct_subst M (idSubst M).
 
   Proof.
-    destruct M.
+    destruct M as [envM ???].
     unfold idSubst; simpl.
-    destruct (isVarDecl_dec env0 0) as [[A EA] | En].
+    destruct (isVarDecl_dec envM 0) as [[A EA] | En].
     simpl; apply one_var_subst_correct; simpl.
     intros; inversion EA; inversion H; try_solve.
     apply env_comp_refl.
     simpl; apply one_var_subst_correct; simpl.
-    intros A E0; inversion E0; inversion En; destruct env0; try_solve.
-    destruct env0.
+    intros A E0; inversion E0; inversion En; destruct envM; try_solve.
+    destruct envM.
     apply env_comp_sym; apply env_comp_empty.
     destruct o.
     inversion En; try_solve.
@@ -1142,14 +1142,14 @@ Module TermsSubst (Sig : TermsSig.Signature).
     apply terms_conv_criterion.
      (* env *)
     rewrite subst_env.
-    destruct M; unfold idSubst; simpl.
-    destruct (isVarDecl_dec env0 0) as [[A EA] | En]; simpl.
-    destruct env0; try destruct o; try_solve.
+    destruct M as [envM ???]; unfold idSubst; simpl.
+    destruct (isVarDecl_dec envM 0) as [[A EA] | En]; simpl.
+    destruct envM; try destruct o; try_solve.
     rewrite env_sub_empty.
     rewrite env_sum_double.
     apply env_comp_refl.
     unfold subst_ran; simpl.
-    destruct env0; try_solve.
+    destruct envM; try_solve.
     destruct o.
     inversion En; try_solve.
     simpl; rewrite env_sub_empty; rewrite env_sum_empty_r.

--- a/Term/SimpleType/TermsSubstConv.v
+++ b/Term/SimpleType/TermsSubstConv.v
@@ -267,8 +267,8 @@ Module TermsSubstConv (Sig : TermsSig.Signature).
     destruct (subst_dom_varSubst_rev G' pG') as [W [G'W WA]].
     destruct GG'.
     destruct (sc_inj_r0 p W G'W) as [q qp].
-    destruct MG.
-    apply (dom_c0 q A B).
+    destruct MG as [envsMG domMG ranMG].
+    apply (domMG q A B).
     destruct (sc_rl0 q p W qp G'W) as [W' [GW' WW']].
     rewrite <- WA.
     assert (W_W': W' ~ W).
@@ -285,11 +285,11 @@ Module TermsSubstConv (Sig : TermsSig.Signature).
     destruct (subst_ran_decl G' pG') as [W [i [G'i Wp]]].
     destruct (sc_inj_r GG' G'i) as [m ml].
     destruct (sc_rl GG' m ml G'i) as [W' [GmW' WW']].
-    destruct MG.
+    destruct MG as [envsMG domMG ranMG].
     set (Wmin := G'min i W G'i).
     rewrite Wmin in Wp.
     destruct (terms_conv_activeEnv_rev WW' Wp) as [q qp].
-    apply (ran_c0 q A B).
+    apply (ranMG q A B).
     apply env_sub_ly_rn.
     apply (subst_ran_decl_conv) with G' S p; trivial.
     apply subst_dom_varNotSubst.

--- a/Term/SimpleType/TermsTyping.v
+++ b/Term/SimpleType/TermsTyping.v
@@ -172,11 +172,11 @@ Resolve, otherwise it does not work! *)
     type M = type N -> M = N.
 
   Proof.
-    intros; destruct M; destruct N; simpl in *.
-    revert typing0.
+    intros [??? typingM] [??? typingN] H H0 H1; simpl in *.
+    revert typingM.
     rewrite H; rewrite H0; rewrite H1.
     intros.
-    rewrite(typing_unique typing0 typing1).
+    rewrite(typing_unique typingM typingN).
     apply eq_refl.
   Qed.
 
@@ -184,10 +184,10 @@ Resolve, otherwise it does not work! *)
     type M = type N.
 
   Proof.
-    intros; destruct M; destruct N; simpl in *.
-    revert typing0.
+    intros; destruct M as [??? typingM]; destruct N as [??? typingN]; simpl in *.
+    revert typingM.
     rewrite H; rewrite H0; intros.
-    apply (Type_unique typing0 typing1).
+    apply (Type_unique typingM typingN).
   Qed.
 
   Lemma term_eq : forall M N, env M = env N -> term M = term N -> M = N.

--- a/Util/FGraph/FGraph.v
+++ b/Util/FGraph/FGraph.v
@@ -289,8 +289,8 @@ same relation *)
   Lemma In_succs_rel : forall g x y, XSet.In y (succs x g) <-> rel g x y.
 
   Proof.
-    intros. unfold succs, rel. destruct (find x g); split_all.
-    ex t0. tauto. inversion H. hyp. revert H. set_iff. tauto. discr.
+    intros. unfold succs, rel. destruct (find x g) as [t|]; split_all.
+    ex t. tauto. inversion H. hyp. revert H. set_iff. tauto. discr.
   Qed.
 
   Lemma mem_succs_rel : forall g x y,
@@ -318,13 +318,13 @@ same relation *)
 
   Proof.
     intros x x' xx' g g' gg'. unfold succs. rewrite <- xx'. clear x' xx'.
-    case_eq (find x g); intros; case_eq (find x g'); intros.
+    destruct (find x g) as [t|] eqn:H; destruct (find x g') as [t0|] eqn:H0.
     (* find x g = Some t0, find x g' = Some t1 *)
     intros y hy.
-    assert (xy : rel g x y). exists t0. intuition. rewrite gg' in xy.
-    destruct xy as [s [s1 s2]]. rewrite H0 in s1. inversion s1. subst t1. hyp.
+    assert (xy : rel g x y). exists t. intuition. rewrite gg' in xy.
+    destruct xy as [s [s1 s2]]. rewrite H0 in s1. inversion s1. subst t0. hyp.
     (* find x g = Some t0, find x g' = None *)
-    case_eq (XSet.is_empty t0); intros.
+    case_eq (XSet.is_empty t); intros.
     rewrite is_empty_eq in H1. rewrite H1. refl.
     destruct (find_Some_rel H H1) as [y hy]. rewrite gg' in hy.
     destruct hy as [s [s1 s2]]. rewrite H0 in s1. discr.

--- a/Util/Multiset/MultisetOrder.v
+++ b/Util/Multiset/MultisetOrder.v
@@ -1158,9 +1158,9 @@ Section OrderSim.
     induction xs.
 
      (* induction base *)
-    intros; inversion H.
-    exists (nil (A:=A)).
-    exists (nil (A:=A)); split.
+    intros ? A B H H0; inversion H.
+    exists (nil (A:=Eq.A)).
+    exists (nil (A:=Eq.A)); split.
     solve_meq.
     split.
     rewrite (multiset2list_meq_empty).
@@ -1168,35 +1168,35 @@ Section OrderSim.
     exact (union_isempty (meq_sym H0)).
     rewrite (multiset2list_meq_empty).
     constructor.
-    assert (empty =mul= B + A0).
+    assert (empty =mul= B + A).
     eauto with multisets.
     exact (union_isempty (meq_sym H1)).
 
      (* induction step *)
-    intros.
+    intros ? A B H H0.
     inversion H.
     rewrite <- H4 in H.
     simpl in H0.
-    assert (list2multiset xs + {{a}} =mul= A0 + B).
+    assert (list2multiset xs + {{a}} =mul= A + B).
     eauto with multisets.
     clear H0.
-    assert (a_A0B: a in (A0 + B)).
+    assert (a_AB: a in (A + B)).
     rewrite <- H6; auto with multisets.
-    destruct (member_union a_A0B) as [aA0 | aB].
+    destruct (member_union a_AB) as [aA | aB].
 
      (* a in A *)
-    destruct (IHxs ys (remove a A0) B H5 (ins_meq_union H6 aA0)) 
+    destruct (IHxs ys (remove a A) B H5 (ins_meq_union H6 aA))
       as [A' [B' [ys' [simL simR]]]].
     inversion H.
-    destruct (list_sim_remove H9 aA0 simL) as [C [CA Csim]].
+    destruct (list_sim_remove H9 aA simL) as [C [CA Csim]].
     exists C; exists B'; split; [idtac | split]; trivial.
     simpl; rewrite CA, ys'; solve_meq.
 
      (* a in B *)
-    assert (list2multiset xs =mul= A0 + (remove a B)).
-    rewrite (union_comm A0 (remove a B)).
+    assert (list2multiset xs =mul= A + (remove a B)).
+    rewrite (union_comm A (remove a B)).
     unfold remove; apply ins_meq_union; eauto with multisets.
-    destruct (IHxs ys A0 (remove a B) H5 H0) as [A' [B' [ys' [simL simR]]]].
+    destruct (IHxs ys A (remove a B) H5 H0) as [A' [B' [ys' [simL simR]]]].
     inversion H.
     destruct (list_sim_remove H10 aB simR) as [C [CA Csim]].
     exists A'; exists C; split; [idtac | split]; trivial.


### PR DESCRIPTION
Should be backwards compatible.