### PR TITLE
coq-13969 overlay, backwards compatible (speeds up rewrites)

### DIFF
--- a/Term/Lambda/LTerm.v
+++ b/Term/Lambda/LTerm.v
@@ -493,6 +493,8 @@ Module Type Var.
 
   Declare Module Export XSet : FSetInterface.S with Module E := XOrd.
 
+  #[global] Declare Instance eq_rel : @RelationClasses.RewriteRelation t Equal.
+
   Notation ens_X :=
     (@mk_Ens X XSet.t empty singleton add union remove diff In mem fold).
 
@@ -519,6 +521,8 @@ Module NatVar <: Var.
   Module XOrd := OrderedTypeEx.Nat_as_OT.
 
   Module Export XSet := FSetAVL.Make XOrd.
+
+  #[global] Instance eq_rel : @RelationClasses.RewriteRelation t Equal := {}.
 
   Notation ens_X :=
     (@mk_Ens X XSet.t empty singleton add union remove diff In mem fold).


### PR DESCRIPTION
Overlay for PR coq/coq#13969 
This favors `Equal` over the `Subset` relation when inferring signatures
of morphisms during rewrites, speeding up inference.
An alternative would be to have the equivalence_rewrite_relation instance
unconstrained in Coq's stdlib but that results in a lot more backtracking.