### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/MatrixInt/ATropicalInt.v
+++ b/MatrixInt/ATropicalInt.v
@@ -10,7 +10,7 @@ Set Implicit Arguments.
 From CoLoR Require Import ATropicalBasedInt Matrix OrdSemiRing VecUtil AMonAlg
      SN RelUtil NatUtil AWFMInterpretation LogicUtil AMatrixBasedInt BoolUtil
      ListUtil.
-From Coq Require Import Structures.Equalities.
+From Coq.Structures Require Import Equalities.
 
 (* TODO: this should be moved to Matrix.v *)
 Module Import TropicalMatrix := Matrix TropicalOrdSemiRingT.

--- a/Term/Lambda/LCompInt.v
+++ b/Term/Lambda/LCompInt.v
@@ -14,7 +14,8 @@ term are computable.
 
 Set Implicit Arguments.
 
-From Coq Require Import IndefiniteDescription Structures.OrderedType.
+From Coq Require Import IndefiniteDescription.
+From Coq.Structures Require Import OrderedType.
 From CoLoR Require Import LogicUtil SN LCompSimple Tarski VecUtil SetUtil
      RelUtil.
 From CoLoR Require Union SetUtil RelUtil AccUtil.

--- a/Term/Lambda/LSystemT.v
+++ b/Term/Lambda/LSystemT.v
@@ -11,7 +11,8 @@ See the COPYRIGHTS and LICENSE files.
 Set Implicit Arguments.
 
 From CoLoR Require Import LogicUtil OrdUtil LSimple RelUtil.
-From Coq Require Import Structures.Equalities Lia.
+From Coq.Structures Require Import Equalities.
+From Coq Require Import Lia.
 From CoLoR Require SetUtil.
 
 

--- a/Term/Lambda/LTerm.v
+++ b/Term/Lambda/LTerm.v
@@ -26,7 +26,8 @@ therefore put in a module [Def] in order to be refered later
 
 Set Implicit Arguments.
 
-From Coq Require Import FSets Structures.OrderedType.
+From Coq Require Import FSets.
+From Coq.Structures Require Import OrderedType.
 From CoLoR Require Import LogicUtil BoolUtil VecUtil FSetUtil NatUtil RelUtil
      SN SetUtil.
 From CoLoR Require Union.

--- a/Util/Logic/EqUtil.v
+++ b/Util/Logic/EqUtil.v
@@ -9,7 +9,7 @@ general lemmas and tactics
 
 Set Implicit Arguments.
 
-From Coq Require Import Structures.Equalities.
+From Coq.Structures Require Import Equalities.
 From Coq Require Export EqdepFacts Eqdep_dec.
 From Coq Require Setoid.
 

--- a/Util/Relation/OrdUtil.v
+++ b/Util/Relation/OrdUtil.v
@@ -12,7 +12,7 @@ See the COPYRIGHTS and LICENSE files.
 Set Implicit Arguments.
 
 From CoLoR Require Import LogicUtil RelUtil SN EqUtil.
-From Coq Require Export Structures.OrderedType.
+From Coq.Structures Require Export OrderedType.
 
 (***********************************************************************)
 (** Properties of [CompOpp]. *)

--- a/Util/Vector/VecUtil.v
+++ b/Util/Vector/VecUtil.v
@@ -14,7 +14,9 @@ See the COPYRIGHTS and LICENSE files.
 
 Set Implicit Arguments.
 
-From Coq Require Import Vector Program Structures.Equalities Morphisms.
+From Coq Require Import Vector Program.
+From Coq.Structures Require Import Equalities.
+From Coq Require Import Morphisms.
 From CoLoR Require Import LogicUtil NatUtil EqUtil ListUtil BoolUtil RelUtil.
 
 Notation vector := Vector.t.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
